### PR TITLE
Feature/opixxx step2 PR

### DIFF
--- a/src/main/java/org/c4marathon/assignment/statistics/controller/StatisticsController.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/controller/StatisticsController.java
@@ -2,14 +2,14 @@ package org.c4marathon.assignment.statistics.controller;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.c4marathon.assignment.statistics.dto.StatisticsResponse;
 import org.c4marathon.assignment.statistics.service.StatisticsService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -21,5 +21,14 @@ public class StatisticsController {
     public ResponseEntity<Void> getStatistics(@RequestParam int pageSize, @RequestParam @NotNull LocalDate date) {
         statisticsService.calculateStatistics(pageSize, date);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/statistics")
+    public ResponseEntity<List<StatisticsResponse>> getStatisticsByStartDateAndEndDate(
+            @RequestParam("startDate") @NotNull LocalDate startDate,
+            @RequestParam("endDate") @NotNull LocalDate endDate
+    ) {
+        List<StatisticsResponse> statisticsByDate = statisticsService.getStatisticsByStartDateAndEndDate(startDate, endDate);
+        return ResponseEntity.status(HttpStatus.CREATED).body(statisticsByDate);
     }
 }

--- a/src/main/java/org/c4marathon/assignment/statistics/controller/StatisticsController.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/controller/StatisticsController.java
@@ -1,0 +1,25 @@
+package org.c4marathon.assignment.statistics.controller;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.c4marathon.assignment.statistics.service.StatisticsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class StatisticsController {
+    private final StatisticsService statisticsService;
+
+    @PostMapping("/statistics")
+    public ResponseEntity<Void> getStatistics(@RequestParam int pageSize, @RequestParam @NotNull LocalDate date) {
+        statisticsService.calculateStatistics(pageSize, date);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/statistics/controller/StatisticsController.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/controller/StatisticsController.java
@@ -18,7 +18,7 @@ public class StatisticsController {
     private final StatisticsService statisticsService;
 
     @PostMapping("/statistics")
-    public ResponseEntity<Void> getStatistics(@RequestParam int pageSize, @RequestParam @NotNull LocalDate date) {
+    public ResponseEntity<Void> calculateStatistics(@RequestParam int pageSize, @RequestParam @NotNull LocalDate date) {
         statisticsService.calculateStatistics(pageSize, date);
         return ResponseEntity.noContent().build();
     }
@@ -29,6 +29,12 @@ public class StatisticsController {
             @RequestParam("endDate") @NotNull LocalDate endDate
     ) {
         List<StatisticsResponse> statisticsByDate = statisticsService.getStatisticsByStartDateAndEndDate(startDate, endDate);
-        return ResponseEntity.status(HttpStatus.CREATED).body(statisticsByDate);
+        return ResponseEntity.ok(statisticsByDate);
+    }
+
+    @PostMapping("/statistics/date")
+    public ResponseEntity<Void> calculateStatisticsForDate(@RequestParam @NotNull LocalDate date) {
+        statisticsService.calculateStatisticsForDay(date);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/Statistics.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/Statistics.java
@@ -1,0 +1,49 @@
+package org.c4marathon.assignment.statistics.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "statistics_opixxx")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Statistics {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "statistics_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate statisticsDate; //통계 기준 날짜
+
+    @Column(nullable = false)
+    private Long totalRemittance; //당일 송금
+
+    @Column(nullable = false)
+    private Long cumulativeRemittance; //누적 송금 금액
+
+    @Column(nullable = false)
+    private LocalDateTime createAt; //통계를 낸 시간
+
+    @Builder
+    private Statistics(LocalDate statisticsDate, Long totalRemittance, Long cumulativeRemittance, LocalDateTime createAt) {
+        this.statisticsDate = statisticsDate;
+        this.totalRemittance = totalRemittance;
+        this.cumulativeRemittance = cumulativeRemittance;
+        this.createAt = createAt;
+    }
+
+    public static Statistics of(LocalDate statisticsDate, Long totalRemittance, Long cumulativeRemittance, LocalDateTime createAt) {
+        return Statistics.builder()
+                .statisticsDate(statisticsDate)
+                .totalRemittance(totalRemittance)
+                .cumulativeRemittance(cumulativeRemittance)
+                .createAt(createAt)
+                .build();
+    }
+
+}

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/Statistics.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/Statistics.java
@@ -46,4 +46,12 @@ public class Statistics {
                 .build();
     }
 
+    public void update(LocalDate statisticsDate, Long totalRemittance, Long cumulativeRemittance, LocalDateTime createAt) {
+        this.statisticsDate = statisticsDate;
+        this.totalRemittance += totalRemittance;
+        this.cumulativeRemittance = cumulativeRemittance;
+        this.createAt = createAt;
+    }
+
+
 }

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 public interface StatisticsJpaRepository extends JpaRepository<Statistics, Long> {
 

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface StatisticsJpaRepository extends JpaRepository<Statistics, Long> {
 
@@ -23,4 +24,13 @@ public interface StatisticsJpaRepository extends JpaRepository<Statistics, Long>
     WHERE s.statisticsDate = :transactionDate
     """)
     Statistics findByStatisticsDate(@Param("transactionDate") LocalDate transactionDate);
+
+    // index(statisticsDate)
+    @Query("""
+    SELECT s
+    FROM Statistics s
+    WHERE s.statisticsDate BETWEEN :startDate AND :endDate
+    """)
+    List<Statistics> findByStatisticsByStartDateAndEndDate(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
 }

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface StatisticsJpaRepository extends JpaRepository<Statistics, Long> {
 
+    // index(statisticsDate)
     @Query("""
     SELECT s.cumulativeRemittance
     FROM Statistics s
@@ -18,6 +19,7 @@ public interface StatisticsJpaRepository extends JpaRepository<Statistics, Long>
     """)
     Long getLatestCumulativeRemittance();
 
+    // index(statisticsDate)
     @Query("""
     SELECT s
     FROM Statistics s

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsJpaRepository.java
@@ -1,0 +1,27 @@
+package org.c4marathon.assignment.statistics.domain.repository;
+
+import org.c4marathon.assignment.statistics.domain.Statistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface StatisticsJpaRepository extends JpaRepository<Statistics, Long> {
+
+    @Query("""
+    SELECT s.cumulativeRemittance
+    FROM Statistics s
+    ORDER BY s.statisticsDate DESC
+    LIMIT 1
+    """)
+    Long getLatestCumulativeRemittance();
+
+    @Query("""
+    SELECT s
+    FROM Statistics s
+    WHERE s.statisticsDate = :transactionDate
+    """)
+    Statistics findByStatisticsDate(@Param("transactionDate") LocalDate transactionDate);
+}

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsRepository.java
@@ -5,6 +5,7 @@ import org.c4marathon.assignment.statistics.domain.Statistics;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +23,10 @@ public class StatisticsRepository {
 
     public void save(Statistics statistics) {
         statisticsJpaRepository.save(statistics);
+    }
+
+    public List<Statistics> findByStatisticsByStartDateAndEndDate(LocalDate startDate, LocalDate endDate) {
+        return statisticsJpaRepository.findByStatisticsByStartDateAndEndDate(startDate, endDate);
     }
 }
 

--- a/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/domain/repository/StatisticsRepository.java
@@ -1,0 +1,27 @@
+package org.c4marathon.assignment.statistics.domain.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.c4marathon.assignment.statistics.domain.Statistics;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+@RequiredArgsConstructor
+public class StatisticsRepository {
+    private final StatisticsJpaRepository statisticsJpaRepository;
+
+    public Long getLatestCumulativeRemittance() {
+        Long latestCumulativeRemittance = statisticsJpaRepository.getLatestCumulativeRemittance();
+        return latestCumulativeRemittance != null ? latestCumulativeRemittance : 0L;
+    }
+
+    public Statistics findByStatisticsDate(LocalDate transactionDate) {
+        return statisticsJpaRepository.findByStatisticsDate(transactionDate);
+    }
+
+    public void save(Statistics statistics) {
+        statisticsJpaRepository.save(statistics);
+    }
+}
+

--- a/src/main/java/org/c4marathon/assignment/statistics/dto/StatisticsResponse.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/dto/StatisticsResponse.java
@@ -1,0 +1,20 @@
+package org.c4marathon.assignment.statistics.dto;
+
+import org.c4marathon.assignment.statistics.domain.Statistics;
+
+import java.time.LocalDate;
+
+public record StatisticsResponse(
+        LocalDate statisticsDate,
+        Long totalRemittance,
+        Long cumulativeRemittance
+) {
+    public StatisticsResponse(Statistics statistics) {
+        this(
+                statistics.getStatisticsDate(),
+                statistics.getTotalRemittance(),
+                statistics.getCumulativeRemittance()
+        );
+    }
+}
+

--- a/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.c4marathon.assignment.statistics.domain.Statistics;
 import org.c4marathon.assignment.statistics.domain.repository.StatisticsRepository;
+import org.c4marathon.assignment.statistics.dto.StatisticsResponse;
 import org.c4marathon.assignment.transaction.domain.Transaction;
 import org.c4marathon.assignment.transaction.domain.repository.TransactionRepository;
 import org.c4marathon.assignment.util.QueryExecuteTemplate;
@@ -61,7 +62,6 @@ public class StatisticsService {
         saveOrUpdateStatistics(date, totalRemittance, latestCumulativeRemittance);
     }
 
-
     public void calculateStatistics(int pageSize, LocalDate endDate) {
 
         AtomicLong latestCumulativeRemittance = new AtomicLong(statisticsRepository.getLatestCumulativeRemittance());
@@ -74,6 +74,20 @@ public class StatisticsService {
                         1000),
                 transactionList -> latestCumulativeRemittance.set(processTransactionBatch(transactionList, latestCumulativeRemittance.get()))
         );
+    }
+
+    /**
+     * 시작날짜와 종료날짜를 입력받아 통계 데이터를 조회하는 로직
+     * @param startDate
+     * @param endDate
+     * @return
+     */
+    public List<StatisticsResponse> getStatisticsByStartDateAndEndDate(LocalDate startDate, LocalDate endDate) {
+        List<Statistics> statisticsByDate = statisticsRepository.findByStatisticsByStartDateAndEndDate(startDate, endDate);
+
+        return statisticsByDate.stream()
+                .map(StatisticsResponse::new)
+                .toList();
     }
 
     /*
@@ -131,4 +145,5 @@ public class StatisticsService {
         statisticsRepository.save(statistics);
 
     }
+
 }

--- a/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
@@ -10,6 +10,7 @@ import org.c4marathon.assignment.transaction.domain.repository.TransactionReposi
 import org.c4marathon.assignment.util.QueryExecuteTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.*;
 import java.util.List;
@@ -31,6 +32,7 @@ public class StatisticsService {
      * 새벽 4시 전날 통계를 집계
      */
     @Scheduled(cron = "0 0 4 * * ?")
+    @Transactional
     public void scheduleStatistics() {
         calculateScheduleStatistics();
     }
@@ -75,6 +77,7 @@ public class StatisticsService {
      * @param pageSize
      * @param endDate
      */
+    @Transactional
     public void calculateStatistics(int pageSize, LocalDate endDate) {
 
         AtomicLong latestCumulativeRemittance = new AtomicLong(statisticsRepository.getLatestCumulativeRemittance());
@@ -95,6 +98,7 @@ public class StatisticsService {
      * @param endDate
      * @return
      */
+    @Transactional(readOnly = true)
     public List<StatisticsResponse> getStatisticsByStartDateAndEndDate(LocalDate startDate, LocalDate endDate) {
         List<Statistics> statisticsByDate = statisticsRepository.findByStatisticsByStartDateAndEndDate(startDate, endDate);
 

--- a/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
@@ -35,9 +35,7 @@ public class StatisticsService {
                         lastTransaction == null ? null : lastTransaction.getTransactionDate(),
                         lastTransaction == null ? 0 : lastTransaction.getId(),
                         1000),
-                transactionList -> {
-                    latestCumulativeRemittance.set(processTransactionBatch(transactionList, latestCumulativeRemittance.get()));
-                }
+                transactionList -> latestCumulativeRemittance.set(processTransactionBatch(transactionList, latestCumulativeRemittance.get()))
         );
     }
 

--- a/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
@@ -1,0 +1,95 @@
+package org.c4marathon.assignment.statistics.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.c4marathon.assignment.statistics.domain.Statistics;
+import org.c4marathon.assignment.statistics.domain.repository.StatisticsRepository;
+import org.c4marathon.assignment.transaction.domain.Transaction;
+import org.c4marathon.assignment.transaction.domain.repository.TransactionRepository;
+import org.c4marathon.assignment.util.QueryExecuteTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+
+    private final TransactionRepository transactionRepository;
+    private final StatisticsRepository statisticsRepository;
+
+
+    public void calculateStatistics(int pageSize, LocalDate endDate) {
+
+        AtomicLong latestCumulativeRemittance = new AtomicLong(statisticsRepository.getLatestCumulativeRemittance());
+
+        QueryExecuteTemplate.<Transaction>selectAndExecuteWithCursorAndPageLimit(pageSize, 1000,
+                lastTransaction -> transactionRepository.findTransactionByLastDate(
+                        endDate,
+                        lastTransaction == null ? null : lastTransaction.getTransactionDate(),
+                        lastTransaction == null ? 0 : lastTransaction.getId(),
+                        1000),
+                transactionList -> {
+                    latestCumulativeRemittance.set(processTransactionBatch(transactionList, latestCumulativeRemittance.get()));
+                }
+        );
+    }
+
+    /*
+     * 넘어온 거래 데이터를 날짜별로 그룹화해서 계산해서 통계 테이블에 저장
+     * 만약 그 날짜에 해당하는 통계 데이터가 있으면 거기다가 누적해서 저장
+     * */
+    private Long processTransactionBatch(List<Transaction> transactionList, Long latestCumulativeRemittance) {
+        ZoneId zoneId = ZoneId.of("UTC");
+
+        //transactionList 에서 데이터가 1/1, 1/2 같이들어올 경우
+        // 여기서 맵으로 만들때 1/2일이 먼저 들어갈 수 있다...?
+        // 그래서 누적할 때 꼬인다 이거 한 번 체크해보기
+        Map<LocalDate, List<Transaction>> map = transactionList.stream()
+                .collect(Collectors.groupingBy(transaction -> LocalDate.ofInstant(transaction.getTransactionDate(), zoneId)));
+
+
+        for (Map.Entry<LocalDate, List<Transaction>> entry : map.entrySet()) {
+            LocalDate transactionDate = entry.getKey();
+            List<Transaction> transactionsByDate = entry.getValue();
+
+            long totalRemittance = transactionsByDate.stream()
+                    .mapToLong(Transaction::getAmount)
+                    .sum();
+
+            latestCumulativeRemittance += totalRemittance;
+
+            saveOrUpdateStatistics(transactionDate, totalRemittance, latestCumulativeRemittance);
+        }
+        return latestCumulativeRemittance;
+    }
+
+    private void saveOrUpdateStatistics(LocalDate transactionDate, Long totalRemittance, Long latestCumulativeRemittance) {
+
+        Statistics statistics = statisticsRepository.findByStatisticsDate(transactionDate);
+
+        if (statistics == null) {
+            statistics = Statistics.of(
+                    transactionDate,
+                    totalRemittance,
+                    latestCumulativeRemittance,
+                    LocalDateTime.now()
+            );
+        } else {
+            statistics.update(
+                    transactionDate,
+                    totalRemittance,
+                    statistics.getCumulativeRemittance() + totalRemittance,
+                    LocalDateTime.now()
+            );
+        }
+        statisticsRepository.save(statistics);
+
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/statistics/service/StatisticsService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.time.*;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -48,9 +49,13 @@ public class StatisticsService {
 
         //transactionList 에서 데이터가 1/1, 1/2 같이들어올 경우
         // 여기서 맵으로 만들때 1/2일이 먼저 들어갈 수 있다...?
-        // 그래서 누적할 때 꼬인다 이거 한 번 체크해보기
+        // 그래서 누적할 때 꼬인다 이거 한 번 체크해보기 -> TreeMap 로 날짜로 정렬
         Map<LocalDate, List<Transaction>> map = transactionList.stream()
-                .collect(Collectors.groupingBy(transaction -> LocalDate.ofInstant(transaction.getTransactionDate(), zoneId)));
+                .collect(Collectors.groupingBy(
+                        transaction -> LocalDate.ofInstant(transaction.getTransactionDate(), zoneId),
+                        TreeMap::new,
+                        Collectors.toList()
+                ));
 
 
         for (Map.Entry<LocalDate, List<Transaction>> entry : map.entrySet()) {

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/Transaction.java
@@ -1,0 +1,65 @@
+package org.c4marathon.assignment.transaction.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "transaction")
+public class Transaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transaction_id", nullable = false)
+    private Integer id;
+
+    @Size(max = 20)
+    @NotNull
+    @Column(name = "sender_account", nullable = false, length = 20)
+    private String senderAccount;
+
+    @Size(max = 20)
+    @NotNull
+    @Column(name = "receiver_account", nullable = false, length = 20)
+    private String receiverAccount;
+
+    @Size(max = 11)
+    @NotNull
+    @Column(name = "sender_swift_code", nullable = false, length = 11)
+    private String senderSwiftCode;
+
+    @Size(max = 11)
+    @NotNull
+    @Column(name = "receiver_swift_code", nullable = false, length = 11)
+    private String receiverSwiftCode;
+
+    @Size(max = 30)
+    @NotNull
+    @Column(name = "sender_name", nullable = false, length = 30)
+    private String senderName;
+
+    @Size(max = 30)
+    @NotNull
+    @Column(name = "receiver_name", nullable = false, length = 30)
+    private String receiverName;
+
+    @NotNull
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Size(max = 200)
+    @Column(name = "memo", length = 200)
+    private String memo;
+
+    @NotNull
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "transaction_date", nullable = false)
+    private Instant transactionDate;
+
+}

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
@@ -34,4 +34,15 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Int
             @Param("lastId") Integer lastId,
             @Param("size") int size
     );
+
+    @Query("""
+    SELECT t
+    FROM Transaction t
+    WHERE DATE(t.transactionDate) = :date
+    ORDER BY t.transactionDate ASC, t.id ASC
+    LIMIT :size
+    """)
+    List<Transaction> findTransactionByDate(@Param("date") LocalDate date, @Param("size") int size);
+
+
 }

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
@@ -24,26 +24,38 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Int
     @Query("""
     SELECT t
     FROM Transaction t
-    WHERE (t.transactionDate > :lastDate OR (t.transactionDate = :lastDate AND t.id > :lastId))
+    WHERE (t.transactionDate > :transactionDate OR (t.transactionDate = :transactionDate AND t.id > :id))
     AND DATE(t.transactionDate) <= :endDate
     ORDER BY t.transactionDate ASC, t.id ASC
     LIMIT :size
     """)
     List<Transaction> findTransactionWithEndDateAndLastDate(
             @Param("endDate") LocalDate endDate,
-            @Param("lastDate") Instant lastDate,
-            @Param("lastId") Integer lastId,
+            @Param("transactionDate") Instant transactionDate,
+            @Param("id") int id,
             @Param("size") int size
     );
 
     @Query("""
     SELECT t
     FROM Transaction t
-    WHERE DATE(t.transactionDate) = :date
+    WHERE DATE(t.transactionDate) = :transactionDate
     ORDER BY t.transactionDate ASC, t.id ASC
     LIMIT :size
     """)
-    List<Transaction> findTransactionByDate(@Param("date") LocalDate date, @Param("size") int size);
+    List<Transaction> findTransactionByDate(@Param("transactionDate") LocalDate transactionDate, @Param("size") int size);
 
 
+    @Query("""
+    SELECT SUM(t.amount)
+    FROM Transaction t
+    """)
+    Long findAllTransactionAmountSum();
+
+    @Query("""
+    SELECT SUM(t.amount)
+    FROM Transaction t
+    WHERE DATE(t.transactionDate) < :transactionDate
+    """)
+    Long findAllTransactionAmountSumBeforeDate(@Param("transactionDate") LocalDate transactionDate);
 }

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
@@ -1,0 +1,37 @@
+package org.c4marathon.assignment.transaction.domain.repository;
+
+import org.c4marathon.assignment.transaction.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TransactionJpaRepository extends JpaRepository<Transaction, Integer> {
+
+    @Query("""
+    SELECT t
+    FROM Transaction t
+    ORDER BY t.transactionDate ASC, t.id ASC
+    LIMIT :size
+    """)
+    List<Transaction> findTransaction(@Param("size") int size);
+
+
+    @Query("""
+    SELECT t
+    FROM Transaction t
+    WHERE (t.transactionDate > :lastDate OR (t.transactionDate = :lastDate AND t.id > :lastId))
+    AND DATE(t.transactionDate) <= :endDate
+    ORDER BY t.transactionDate ASC, t.id ASC
+    LIMIT :size
+    """)
+    List<Transaction> findTransactionWithEndDateAndLastDate(
+            @Param("endDate") LocalDate endDate,
+            @Param("lastDate") Instant lastDate,
+            @Param("lastId") Integer lastId,
+            @Param("size") int size
+    );
+}

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionJpaRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public interface TransactionJpaRepository extends JpaRepository<Transaction, Integer> {
 
+    // index(transactionDate)
     @Query("""
     SELECT t
     FROM Transaction t

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionRepository.java
@@ -1,0 +1,22 @@
+package org.c4marathon.assignment.transaction.domain.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.c4marathon.assignment.transaction.domain.Transaction;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class TransactionRepository {
+    private final TransactionJpaRepository transactionJpaRepository;
+
+    public List<Transaction> findTransactionByLastDate(LocalDate endDate, Instant lastDate, int lastId, int size) {
+        if (lastDate == null) {
+            return transactionJpaRepository.findTransaction(size);
+        }
+        return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, lastDate, lastId, size);
+    }
+}

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionRepository.java
@@ -19,4 +19,11 @@ public class TransactionRepository {
         }
         return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, lastDate, lastId, size);
     }
+
+    public List<Transaction> findTransactionByDate(LocalDate endDate, Instant lastDate, int lastId, int size) {
+        if (lastDate == null) {
+            return transactionJpaRepository.findTransactionByDate(endDate, size);
+        }
+        return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, lastDate, lastId, size);
+    }
 }

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/repository/TransactionRepository.java
@@ -13,17 +13,26 @@ import java.util.List;
 public class TransactionRepository {
     private final TransactionJpaRepository transactionJpaRepository;
 
-    public List<Transaction> findTransactionByLastDate(LocalDate endDate, Instant lastDate, int lastId, int size) {
-        if (lastDate == null) {
+    public List<Transaction> findTransactionByLastDate(LocalDate endDate, Instant transactionDate, int id, int size) {
+        if (transactionDate == null) {
             return transactionJpaRepository.findTransaction(size);
         }
-        return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, lastDate, lastId, size);
+        return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, transactionDate, id, size);
     }
 
-    public List<Transaction> findTransactionByDate(LocalDate endDate, Instant lastDate, int lastId, int size) {
-        if (lastDate == null) {
+    public List<Transaction> findTransactionByDate(LocalDate endDate, Instant transactionDate, int id, int size) {
+        if (transactionDate == null) {
             return transactionJpaRepository.findTransactionByDate(endDate, size);
         }
-        return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, lastDate, lastId, size);
+        return transactionJpaRepository.findTransactionWithEndDateAndLastDate(endDate, transactionDate, id, size);
     }
+
+    public Long getAllTransactionAmountSum() {
+        return transactionJpaRepository.findAllTransactionAmountSum();
+    }
+
+    public Long getAllTransactionAmountSumBeforeDate(LocalDate date) {
+        return transactionJpaRepository.findAllTransactionAmountSumBeforeDate(date);
+    }
+
 }

--- a/src/main/java/org/c4marathon/assignment/util/QueryExecuteTemplate.java
+++ b/src/main/java/org/c4marathon/assignment/util/QueryExecuteTemplate.java
@@ -1,0 +1,55 @@
+package org.c4marathon.assignment.util;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class QueryExecuteTemplate {
+
+    /*
+     * selectFunction -> 데이터 조회해오는 용도
+     * resultConsumer -> 조회한 데이터를 이용해서 어떤 비즈니스 로직을 수행하는 용도
+     * */
+    public static <T> void selectAndExecuteWithCursor(
+            int limit,
+            Function<T, List<T>> selectFunction,
+            Consumer<List<T>> resultConsumer) {
+
+        List<T> resultList = null;
+        do {
+            resultList = selectFunction.apply(resultList != null ? resultList.get(resultList.size() - 1) : null);
+            if (!resultList.isEmpty()) {
+                resultConsumer.accept(resultList);
+            }
+        } while (resultList.size() >= limit);
+    }
+
+    /*
+     * pageLimit 가 음수이면 실행횟수 제한 없음
+     * iterationCount 가 pageLimit 에 도달하면 중단
+     * 이 메서드는 테스트 용을 위한 메서드(많은 데이터를 다 조회할 순 없잖아)
+     * */
+    public static <T> void selectAndExecuteWithCursorAndPageLimit(
+            int pageLimit,
+            int limit,
+            Function<T, List<T>> selectFunction,
+            Consumer<List<T>> resultConsumer) {
+
+        if (pageLimit < 0) {
+            selectAndExecuteWithCursor(limit, selectFunction, resultConsumer);
+            return;
+        }
+
+        var iterationCount = 0;
+        List<T> resultList = null;
+        do {
+            resultList = selectFunction.apply(resultList != null ? resultList.get(resultList.size() - 1) : null);
+            if (!resultList.isEmpty()) {
+                resultConsumer.accept(resultList);
+            }
+            if (++iterationCount >= pageLimit) {
+                break;
+            }
+        } while (resultList.size() >= limit);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,10 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USER_ID}
     password: ${DB_PASSWORD}
-    url: jdbc:mysql://${DB_URL}/large-scale?socketTimeout=2000
+    url: jdbc:mysql://${DB_URL}/large-scale?socketTimeout=5000&useSSL=false&serverTimezone=UTC
+
     hikari:
-      connection-timeout: 3000
+      connection-timeout: 10000
   jpa:
     show-sql: true
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USER_ID}
     password: ${DB_PASSWORD}
-    url: jdbc:mysql://${DB_URL}/large-scale?socketTimeout=5000&useSSL=false&serverTimezone=UTC
+    url: jdbc:mysql://${DB_URL}/large-scale?socketTimeout=10000&useSSL=false&serverTimezone=UTC
 
     hikari:
       connection-timeout: 10000


### PR DESCRIPTION
- 특정 날짜의 통계를 강제로 집계하는 API
    - QueryExecuteTemplate 를 이용해서 많은 양의 Transaction 데이터를 1000개씩 가져와서 날짜 별로 그룹화 하여 일 단위 송금금액, 누적 송금금액을 계산해서 통계 데이터를 집계함
    - Transaction 데이터의 시간이 UTC 로 되어있어, 시간을 그룹화를 할 때 KST 로 그룹화를 하게 돼 15:00~23:59:59 데이터가 그 다음날로 그룹화가 됨 -> Instant를 LocalDate로 변경할 때 ZoneId를 UTC로 하도록 함 
    ```java
    ZoneId zoneId = ZoneId.of("UTC");
    LocalDate.ofInstant(transaction.getTransactionDate(), zoneId);
    ``` 
    - 1000개씩 조회해온 transactionList 를 날짜별로 그룹화를 하여 누적 금액을 계산할 때 날짜 순서가 엉켜서 계산되는 문제 발견
    -> Map은 순서를 보장하지 않아 생긴 문제같아 그룹화할 때 Map을 TreeMap으로 생성했더니 해결됨
     ```java
      Map<LocalDate, List<Transaction>> map = transactionList.stream()
                .collect(Collectors.groupingBy(
                        transaction -> LocalDate.ofInstant(transaction.getTransactionDate(), zoneId),
                        TreeMap::new,
                        Collectors.toList()
                ));
     ```
  
- 새벽 4시 전날 통계를 집계하는 스케줄러
    - 현재 시각의 1일 전의 데이터를 1000개씩 가져와서 일 단위 송금금액, 누적 송금금액을 계산해서 통계 테이터를 집계함

- 시작날짜, 종료날짜를 받아 통계 데이터를 조회
