### PR TITLE
Feature/zzambas step2: 송금 이력 통계화

### DIFF
--- a/src/main/java/org/c4marathon/assignment/global/util/CustomThreadPoolExecutor.java
+++ b/src/main/java/org/c4marathon/assignment/global/util/CustomThreadPoolExecutor.java
@@ -1,0 +1,80 @@
+package org.c4marathon.assignment.global.util;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CustomThreadPoolExecutor implements Executor {
+	private int queueSize;
+	private int threadCount;
+	private ThreadPoolExecutor threadPoolExecutor;
+	private RuntimeException exception;
+
+	private void init() {
+		this.queueSize = 100;
+		this.threadCount = 8;
+		this.threadPoolExecutor = new ThreadPoolExecutor(threadCount, threadCount, 0L, TimeUnit.MILLISECONDS,
+			new LinkedBlockingQueue<>(queueSize), (r, executor) -> {
+			try {
+				executor.getQueue().put(r);
+			} catch (InterruptedException e) {
+				log.error(e.toString(), e);
+				Thread.currentThread().interrupt();
+			}
+		});
+	}
+
+	@Override
+	public void execute(Runnable command) {
+		if (threadPoolExecutor != null && (threadPoolExecutor.isTerminated() || threadPoolExecutor.isTerminating())) {
+			return;
+		}
+
+		init();
+
+		threadPoolExecutor.execute(() -> {
+			try {
+				command.run();
+			} catch (RuntimeException e) {
+				log.error("처리 중 예외 발생", e);
+				this.exception = e;
+			}
+		});
+	}
+
+	public void waitToEnd() {
+		if (isInvalidState()) {
+			return;
+		}
+
+		this.threadPoolExecutor.shutdown();
+
+		while (true) {
+			try {
+				if (threadPoolExecutor.awaitTermination(Integer.MAX_VALUE, TimeUnit.MILLISECONDS)) {
+					break;
+				}
+			} catch (InterruptedException e) {
+				log.error(e.toString(), e);
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		threadPoolExecutor = null; // 임무를 다한 Executor 지우기
+
+		if (exception != null) { // hold한 예외 던지기
+			throw exception;
+		}
+	}
+
+	private boolean isInvalidState() {
+		return threadPoolExecutor == null || threadPoolExecutor.isTerminating() || threadPoolExecutor.isTerminated();
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/global/util/QueryTemplate.java
+++ b/src/main/java/org/c4marathon/assignment/global/util/QueryTemplate.java
@@ -1,0 +1,25 @@
+package org.c4marathon.assignment.global.util;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class QueryTemplate {
+	private QueryTemplate() {}
+
+	// limit 만큼 배치 처리
+	public static <T> void selectAndExecuteWithCursor(int limit, Function<T, List<T>> selectFunc, Consumer<List<T>> resultFunc) {
+		List<T> resultList = null;
+
+		do {
+			resultList = selectFunc.apply(resultList == null ? null : resultList.get(resultList.size() - 1));
+
+			if (!resultList.isEmpty()) {
+				resultFunc.accept(resultList);
+			}
+		} while (resultList.size() >= limit);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
@@ -43,6 +43,12 @@ public class TransactionStatisticService {
 		this.transactionStatisticRepository = transactionStatisticRepository;
 	}
 
+	public List<TransactionStatisticResult> findAll(Instant start, Instant end) {
+		List<TransactionStatistic> statistics = transactionStatisticRepository.findAll(start, end);
+
+		return statistics.stream().map(TransactionStatisticResult::from).toList();
+	}
+
 	/**
 	 * theDay까지(해당 일 23:59:59까지) 통계를 집계합니다.
 	 * @param theDay

--- a/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.statistic.application;
+
+import org.c4marathon.assignment.statistic.domain.TransactionStatisticRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransactionStatisticService {
+	private final TransactionStatisticRepository statisticRepository;
+
+	public TransactionStatisticService(TransactionStatisticRepository statisticRepository) {
+		this.statisticRepository = statisticRepository;
+	}
+
+
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -14,7 +13,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import org.c4marathon.assignment.global.util.QueryTemplate;
 import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
@@ -22,6 +20,7 @@ import org.c4marathon.assignment.statistic.domain.TransactionStatisticRepository
 import org.c4marathon.assignment.statistic.dto.TransactionStatisticResult;
 import org.c4marathon.assignment.transaction.domain.Transaction;
 import org.c4marathon.assignment.transaction.domain.TransactionRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +43,13 @@ public class TransactionStatisticService {
 		this.transactionStatisticRepository = transactionStatisticRepository;
 	}
 
+	/**
+	 * theDay까지(해당 일 23:59:59까지) 통계를 집계합니다.
+	 * @param theDay
+	 * @return
+	 */
 	public TransactionStatisticResult aggregate(Instant theDay) {
+		log.info("theDay: {}", theDay);
 		Optional<TransactionStatistic> statisticOptional = statisticRepository.findCloseStatisticByStatisticDate(theDay);
 
 		if (statisticOptional.isPresent() && Objects.equals(statisticOptional.get().getStatisticDate(), theDay)) {
@@ -128,5 +133,10 @@ public class TransactionStatisticService {
 		}
 
 		return statistics;
+	}
+
+	@Scheduled(cron = "0 0 4 * * *")
+	private void calculateStatistic() {
+		aggregate(Instant.now().plus(9L, ChronoUnit.HOURS));
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
@@ -3,15 +3,19 @@ package org.c4marathon.assignment.statistic.application;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
-import org.c4marathon.assignment.global.util.CustomThreadPoolExecutor;
 import org.c4marathon.assignment.global.util.QueryTemplate;
 import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
 import org.c4marathon.assignment.statistic.domain.TransactionStatisticRepository;
@@ -31,87 +35,67 @@ public class TransactionStatisticService {
 
 	private final TransactionStatisticRepository statisticRepository;
 	private final TransactionRepository transactionRepository;
-	private final CustomThreadPoolExecutor threadPoolExecutor;
 	private final TransactionStatisticRepository transactionStatisticRepository;
 
 	public TransactionStatisticService(TransactionStatisticRepository statisticRepository,
-		TransactionRepository transactionRepository, CustomThreadPoolExecutor threadPoolExecutor,
-		TransactionStatisticRepository transactionStatisticRepository) {
+		TransactionRepository transactionRepository, TransactionStatisticRepository transactionStatisticRepository) {
 		this.statisticRepository = statisticRepository;
 		this.transactionRepository = transactionRepository;
-		this.threadPoolExecutor = threadPoolExecutor;
 		this.transactionStatisticRepository = transactionStatisticRepository;
 	}
 
 	public TransactionStatisticResult aggregate(Instant theDay) {
-		// 0. 통계 테이블에서 집계하려는 날짜의 데이터가 있으면 그걸 반환.
 		Optional<TransactionStatistic> statisticOptional = statisticRepository.findCloseStatisticByStatisticDate(theDay);
 
 		if (statisticOptional.isPresent() && Objects.equals(statisticOptional.get().getStatisticDate(), theDay)) {
 			return TransactionStatisticResult.from(statisticOptional.get());
 		}
 
-		// 1. 통계 테이블에서 그 날짜와 제일 가까운 통계 있는지 확인.
-		// 1-1. 없으면 트랜잭션 테이블 제일 첫 거래 날짜를 가져온다. -> 다음날 자정으로 기록한다.
-		// 		근데 자정을 어떻게 설정할 수 있을까 -> toEpochSecond()로 표현한 뒤, % (3600 * 24)로 나온 값을 짜르자!
-		// 1-1-1 트랜잭션도 없으면 그냥 지금 시간으로 기록한다(가져올 데이터 없도록)
-		// 1-2. 있으면 그것을 가져오고 날짜와 누적 금액에 추가한다.
-
 		Instant endDay = getMidnightOfDay(theDay).plus(1L, ChronoUnit.DAYS);
-		AtomicLong theDayAmount = new AtomicLong(0L);
-		AtomicLong cumulativeAmount = new AtomicLong(0L);
+		long cumulativeAmount = 0L;
 		Instant startDay;
 
 		if (statisticOptional.isPresent()) {
 			TransactionStatistic transactionStatistic = statisticOptional.get();
 			startDay = transactionStatistic.getStatisticDate().plus(1L, ChronoUnit.DAYS);
-			cumulativeAmount.addAndGet(transactionStatistic.getCumulativeAmount());
+			cumulativeAmount = transactionStatistic.getCumulativeAmount();
 		} else {
 			Transaction firstTransaction = transactionRepository.findFirstOrderByTransactionDate().orElse(null);
 			startDay = firstTransaction == null ? Instant.now() : getMidnightOfDay(firstTransaction.getTransactionDate());
 		}
 
-		// 2. theDay 전까지 스레드 풀 각 스레드만큼 3시간 단위(비교하며 적절히 쪼개본다)로 분리하고, 배치로 Transaction 테이블 돌면서 다음을 수행
-		// 2-1. cumulativeAmount에 추가
-		// 2-2. 현재 Instant가 (theDay 그 자정)보다 같거나 크면 theDayAmount에 추가
-
 		List<Instant> splitTimes = getSplitTimes(startDay, endDay);
+
+		Map<Instant, AtomicLong> statisticMap = new TreeMap<>(Comparator.comparing(Instant::getEpochSecond));
+		splitTimes.forEach(splitTime -> statisticMap.putIfAbsent(getMidnightOfDay(splitTime), new AtomicLong()));
 
 		ExecutorService executorService = Executors.newFixedThreadPool(8);
 
 		splitTimes.forEach(splitTime -> executorService.execute(() ->
 			QueryTemplate.<Transaction>selectAndExecuteWithCursor(BATCH_SIZE,
 				transaction -> transactionRepository.findBetweenTimesWithCursor(transaction == null ? splitTime : transaction.getTransactionDate(), splitTime.plusSeconds(SPLIT_SECONDS_PER_THREADS), transaction == null ? null : transaction.getId(), BATCH_SIZE),
-				transactions -> transactions.forEach(transaction -> calculateStatistic(theDay, transaction, cumulativeAmount, theDayAmount)))
+				transactions -> transactions.forEach(transaction -> calculateStatistic(transaction, statisticMap)))
 			)
 		);
 
-		//threadPoolExecutor.waitToEnd();
 		executorService.shutdown();
 		try {
-			executorService.awaitTermination(1L, TimeUnit.HOURS);
+			executorService.awaitTermination(20L, TimeUnit.MINUTES);
 		} catch (Exception e) {
 			log.warn("스레드 풀이 정상적으로 종료되지 않았습니다.");
 		}
 
-		TransactionStatistic transactionStatistic = TransactionStatistic.builder()
-			.dailyTotalAmount(theDayAmount.get())
-			.cumulativeAmount(cumulativeAmount.get())
-			.statisticDate(getMidnightOfDay(theDay))
-			.build();
+		List<TransactionStatistic> statistics = getStatistics(statisticMap, cumulativeAmount);
 
-		transactionStatisticRepository.save(transactionStatistic);
+		transactionStatisticRepository.saveAll(statistics);
 
-		return TransactionStatisticResult.from(transactionStatistic);
+		return TransactionStatisticResult.from(statistics.get(statistics.size() - 1));
 	}
 
-	private void calculateStatistic(Instant theDay, Transaction transaction, AtomicLong cumulativeAmount,
-		AtomicLong theDayAmount) {
-		cumulativeAmount.addAndGet(transaction.getAmount());
+	private void calculateStatistic(Transaction transaction, Map<Instant, AtomicLong> statisticMap) {
+		Instant curTransactionDate = getMidnightOfDay(transaction.getTransactionDate());
 
-		if (isSameDay(transaction.getTransactionDate(), theDay)) {
-			theDayAmount.addAndGet(transaction.getAmount());
-		}
+		statisticMap.get(curTransactionDate).addAndGet(transaction.getAmount());
 	}
 
 	private Instant getMidnightOfDay(Instant time) {
@@ -129,7 +113,20 @@ public class TransactionStatisticService {
 		return splitTimes;
 	}
 
-	private boolean isSameDay(Instant instant1, Instant instant2) {
-		return getMidnightOfDay(instant1).equals(getMidnightOfDay(instant2));
+	private List<TransactionStatistic> getStatistics(Map<Instant, AtomicLong> statisticMap, long cumulativeAmount) {
+		List<TransactionStatistic> statistics = new ArrayList<>();
+		for (var entry : statisticMap.entrySet()) {
+			cumulativeAmount += entry.getValue().get();
+
+			TransactionStatistic transactionStatistic = TransactionStatistic.builder()
+				.statisticDate(entry.getKey())
+				.dailyTotalAmount(entry.getValue().get())
+				.cumulativeAmount(cumulativeAmount)
+				.build();
+
+			statistics.add(transactionStatistic);
+		}
+
+		return statistics;
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/application/TransactionStatisticService.java
@@ -1,15 +1,135 @@
 package org.c4marathon.assignment.statistic.application;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.c4marathon.assignment.global.util.CustomThreadPoolExecutor;
+import org.c4marathon.assignment.global.util.QueryTemplate;
+import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
 import org.c4marathon.assignment.statistic.domain.TransactionStatisticRepository;
+import org.c4marathon.assignment.statistic.dto.TransactionStatisticResult;
+import org.c4marathon.assignment.transaction.domain.Transaction;
+import org.c4marathon.assignment.transaction.domain.TransactionRepository;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 public class TransactionStatisticService {
-	private final TransactionStatisticRepository statisticRepository;
+	private static final long DAY_TIME_SECONDS = 24L * 60L * 60L;
+	private static final long SPLIT_SECONDS_PER_THREADS = 6L * 60L * 60L; // 스레드 별 시간 단위
+	private static final int BATCH_SIZE = 1000;
 
-	public TransactionStatisticService(TransactionStatisticRepository statisticRepository) {
+	private final TransactionStatisticRepository statisticRepository;
+	private final TransactionRepository transactionRepository;
+	private final CustomThreadPoolExecutor threadPoolExecutor;
+	private final TransactionStatisticRepository transactionStatisticRepository;
+
+	public TransactionStatisticService(TransactionStatisticRepository statisticRepository,
+		TransactionRepository transactionRepository, CustomThreadPoolExecutor threadPoolExecutor,
+		TransactionStatisticRepository transactionStatisticRepository) {
 		this.statisticRepository = statisticRepository;
+		this.transactionRepository = transactionRepository;
+		this.threadPoolExecutor = threadPoolExecutor;
+		this.transactionStatisticRepository = transactionStatisticRepository;
 	}
 
+	public TransactionStatisticResult aggregate(Instant theDay) {
+		// 0. 통계 테이블에서 집계하려는 날짜의 데이터가 있으면 그걸 반환.
+		Optional<TransactionStatistic> statisticOptional = statisticRepository.findCloseStatisticByStatisticDate(theDay);
 
+		if (statisticOptional.isPresent() && Objects.equals(statisticOptional.get().getStatisticDate(), theDay)) {
+			return TransactionStatisticResult.from(statisticOptional.get());
+		}
+
+		// 1. 통계 테이블에서 그 날짜와 제일 가까운 통계 있는지 확인.
+		// 1-1. 없으면 트랜잭션 테이블 제일 첫 거래 날짜를 가져온다. -> 다음날 자정으로 기록한다.
+		// 		근데 자정을 어떻게 설정할 수 있을까 -> toEpochSecond()로 표현한 뒤, % (3600 * 24)로 나온 값을 짜르자!
+		// 1-1-1 트랜잭션도 없으면 그냥 지금 시간으로 기록한다(가져올 데이터 없도록)
+		// 1-2. 있으면 그것을 가져오고 날짜와 누적 금액에 추가한다.
+
+		Instant endDay = getMidnightOfDay(theDay).plus(1L, ChronoUnit.DAYS);
+		AtomicLong theDayAmount = new AtomicLong(0L);
+		AtomicLong cumulativeAmount = new AtomicLong(0L);
+		Instant startDay;
+
+		if (statisticOptional.isPresent()) {
+			TransactionStatistic transactionStatistic = statisticOptional.get();
+			startDay = transactionStatistic.getStatisticDate().plus(1L, ChronoUnit.DAYS);
+			cumulativeAmount.addAndGet(transactionStatistic.getCumulativeAmount());
+		} else {
+			Transaction firstTransaction = transactionRepository.findFirstOrderByTransactionDate().orElse(null);
+			startDay = firstTransaction == null ? Instant.now() : getMidnightOfDay(firstTransaction.getTransactionDate());
+		}
+
+		// 2. theDay 전까지 스레드 풀 각 스레드만큼 3시간 단위(비교하며 적절히 쪼개본다)로 분리하고, 배치로 Transaction 테이블 돌면서 다음을 수행
+		// 2-1. cumulativeAmount에 추가
+		// 2-2. 현재 Instant가 (theDay 그 자정)보다 같거나 크면 theDayAmount에 추가
+
+		List<Instant> splitTimes = getSplitTimes(startDay, endDay);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(8);
+
+		splitTimes.forEach(splitTime -> executorService.execute(() ->
+			QueryTemplate.<Transaction>selectAndExecuteWithCursor(BATCH_SIZE,
+				transaction -> transactionRepository.findBetweenTimesWithCursor(transaction == null ? splitTime : transaction.getTransactionDate(), splitTime.plusSeconds(SPLIT_SECONDS_PER_THREADS), transaction == null ? null : transaction.getId(), BATCH_SIZE),
+				transactions -> transactions.forEach(transaction -> calculateStatistic(theDay, transaction, cumulativeAmount, theDayAmount)))
+			)
+		);
+
+		//threadPoolExecutor.waitToEnd();
+		executorService.shutdown();
+		try {
+			executorService.awaitTermination(1L, TimeUnit.HOURS);
+		} catch (Exception e) {
+			log.warn("스레드 풀이 정상적으로 종료되지 않았습니다.");
+		}
+
+		TransactionStatistic transactionStatistic = TransactionStatistic.builder()
+			.dailyTotalAmount(theDayAmount.get())
+			.cumulativeAmount(cumulativeAmount.get())
+			.statisticDate(getMidnightOfDay(theDay))
+			.build();
+
+		transactionStatisticRepository.save(transactionStatistic);
+
+		return TransactionStatisticResult.from(transactionStatistic);
+	}
+
+	private void calculateStatistic(Instant theDay, Transaction transaction, AtomicLong cumulativeAmount,
+		AtomicLong theDayAmount) {
+		cumulativeAmount.addAndGet(transaction.getAmount());
+
+		if (isSameDay(transaction.getTransactionDate(), theDay)) {
+			theDayAmount.addAndGet(transaction.getAmount());
+		}
+	}
+
+	private Instant getMidnightOfDay(Instant time) {
+		return time.minusSeconds(time.getEpochSecond() % DAY_TIME_SECONDS);
+	}
+
+	private List<Instant> getSplitTimes(Instant startTime, Instant endDay) {
+		List<Instant> splitTimes = new ArrayList<>();
+
+		while (startTime.isBefore(endDay)) {
+			splitTimes.add(startTime);
+			startTime = startTime.plusSeconds(SPLIT_SECONDS_PER_THREADS);
+		}
+
+		return splitTimes;
+	}
+
+	private boolean isSameDay(Instant instant1, Instant instant2) {
+		return getMidnightOfDay(instant1).equals(getMidnightOfDay(instant2));
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
@@ -1,0 +1,13 @@
+package org.c4marathon.assignment.statistic.controller;
+
+import org.c4marathon.assignment.statistic.application.TransactionStatisticService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TransactionStatisticController {
+	private final TransactionStatisticService statisticService;
+
+	public TransactionStatisticController(TransactionStatisticService statisticService) {
+		this.statisticService = statisticService;
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
@@ -1,13 +1,26 @@
 package org.c4marathon.assignment.statistic.controller;
 
+import java.time.Instant;
+
 import org.c4marathon.assignment.statistic.application.TransactionStatisticService;
+import org.c4marathon.assignment.statistic.dto.TransactionStatisticResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/statistic/transaction")
 public class TransactionStatisticController {
 	private final TransactionStatisticService statisticService;
 
 	public TransactionStatisticController(TransactionStatisticService statisticService) {
 		this.statisticService = statisticService;
+	}
+
+	@GetMapping("/aggregate")
+	public ResponseEntity<TransactionStatisticResult> aggregate(@RequestParam Instant theDay) {
+		return ResponseEntity.ok(statisticService.aggregate(theDay));
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
@@ -2,6 +2,7 @@ package org.c4marathon.assignment.statistic.controller;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import org.c4marathon.assignment.statistic.application.TransactionStatisticService;
 import org.c4marathon.assignment.statistic.dto.TransactionStatisticResult;
@@ -23,5 +24,11 @@ public class TransactionStatisticController {
 	@GetMapping("/aggregate")
 	public ResponseEntity<TransactionStatisticResult> aggregate(@RequestParam LocalDate theDay) {
 		return ResponseEntity.ok(statisticService.aggregate(theDay.atStartOfDay(ZoneOffset.UTC).toInstant()));
+	}
+
+	@GetMapping("/range")
+	public ResponseEntity<List<TransactionStatisticResult>> findAll(@RequestParam LocalDate startTime, @RequestParam LocalDate endTime) {
+		return ResponseEntity.ok(statisticService.findAll(startTime.atStartOfDay(ZoneOffset.UTC).toInstant(),
+			endTime.atStartOfDay(ZoneOffset.UTC).toInstant()));
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/controller/TransactionStatisticController.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.statistic.controller;
 
-import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.c4marathon.assignment.statistic.application.TransactionStatisticService;
 import org.c4marathon.assignment.statistic.dto.TransactionStatisticResult;
@@ -20,7 +21,7 @@ public class TransactionStatisticController {
 	}
 
 	@GetMapping("/aggregate")
-	public ResponseEntity<TransactionStatisticResult> aggregate(@RequestParam Instant theDay) {
-		return ResponseEntity.ok(statisticService.aggregate(theDay));
+	public ResponseEntity<TransactionStatisticResult> aggregate(@RequestParam LocalDate theDay) {
+		return ResponseEntity.ok(statisticService.aggregate(theDay.atStartOfDay(ZoneOffset.UTC).toInstant()));
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatistic.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatistic.java
@@ -1,6 +1,6 @@
 package org.c4marathon.assignment.statistic.domain;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,7 +19,7 @@ public class TransactionStatistic {
 	private Long id;
 
 	@Column(columnDefinition = "datetime(6)")
-	private LocalDateTime statisticDate;
+	private Instant statisticDate;
 
 	@Column(nullable = false)
 	private long dailyTotalAmount;

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatistic.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatistic.java
@@ -8,11 +8,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "transaction_statistic_zzamba")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TransactionStatistic {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,4 +30,11 @@ public class TransactionStatistic {
 
 	@Column(nullable = false)
 	private long cumulativeAmount;
+
+	@Builder
+	public TransactionStatistic(Instant statisticDate, long dailyTotalAmount, long cumulativeAmount) {
+		this.statisticDate = statisticDate;
+		this.dailyTotalAmount = dailyTotalAmount;
+		this.cumulativeAmount = cumulativeAmount;
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatistic.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatistic.java
@@ -1,0 +1,29 @@
+package org.c4marathon.assignment.statistic.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "transaction_statistic_zzamba")
+public class TransactionStatistic {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(columnDefinition = "datetime(6)")
+	private LocalDateTime statisticDate;
+
+	@Column(nullable = false)
+	private long dailyTotalAmount;
+
+	@Column(nullable = false)
+	private long cumulativeAmount;
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.statistic.domain;
+
+import org.c4marathon.assignment.statistic.infrastructure.TransactionStatisticJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TransactionStatisticRepository {
+	private final TransactionStatisticJpaRepository statisticJpaRepository;
+
+	public TransactionStatisticRepository(TransactionStatisticJpaRepository statisticJpaRepository) {
+		this.statisticJpaRepository = statisticJpaRepository;
+	}
+
+
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
@@ -1,17 +1,22 @@
 package org.c4marathon.assignment.statistic.domain;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.statistic.infrastructure.TransactionStatisticJpaRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class TransactionStatisticRepository {
 	private final TransactionStatisticJpaRepository statisticJpaRepository;
+	private final JdbcTemplate jdbcTemplate;
 
-	public TransactionStatisticRepository(TransactionStatisticJpaRepository statisticJpaRepository) {
+	public TransactionStatisticRepository(TransactionStatisticJpaRepository statisticJpaRepository,
+		JdbcTemplate jdbcTemplate) {
 		this.statisticJpaRepository = statisticJpaRepository;
+		this.jdbcTemplate = jdbcTemplate;
 	}
 
 	public Optional<TransactionStatistic> findCloseStatisticByStatisticDate(Instant theDay) {
@@ -20,5 +25,18 @@ public class TransactionStatisticRepository {
 
 	public void save(TransactionStatistic transactionStatistic) {
 		statisticJpaRepository.save(transactionStatistic);
+	}
+
+	public void saveAll(List<TransactionStatistic> transactionStatistics) {
+		String sql = """
+			INSERT INTO transaction_statistic_zzamba (statistic_date, daily_total_amount, cumulative_amount)
+			VALUES (?, ?, ?)
+			""";
+
+		jdbcTemplate.batchUpdate(sql, transactionStatistics, transactionStatistics.size(), (ps, statistic) -> {
+			ps.setObject(1, statistic.getStatisticDate());
+			ps.setLong(2, statistic.getDailyTotalAmount());
+			ps.setLong(3, statistic.getCumulativeAmount());
+		});
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
@@ -1,5 +1,8 @@
 package org.c4marathon.assignment.statistic.domain;
 
+import java.time.Instant;
+import java.util.Optional;
+
 import org.c4marathon.assignment.statistic.infrastructure.TransactionStatisticJpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +14,11 @@ public class TransactionStatisticRepository {
 		this.statisticJpaRepository = statisticJpaRepository;
 	}
 
+	public Optional<TransactionStatistic> findCloseStatisticByStatisticDate(Instant theDay) {
+		return statisticJpaRepository.findCloseStatisticByStatisticDate(theDay);
+	}
 
+	public void save(TransactionStatistic transactionStatistic) {
+		statisticJpaRepository.save(transactionStatistic);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
@@ -2,7 +2,6 @@ package org.c4marathon.assignment.statistic.domain;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 import org.c4marathon.assignment.statistic.infrastructure.TransactionStatisticJpaRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -19,8 +18,8 @@ public class TransactionStatisticRepository {
 		this.jdbcTemplate = jdbcTemplate;
 	}
 
-	public Optional<TransactionStatistic> findCloseStatisticByStatisticDate(Instant theDay) {
-		return statisticJpaRepository.findCloseStatisticByStatisticDate(theDay);
+	public void save(TransactionStatistic statistic) {
+		statisticJpaRepository.save(statistic);
 	}
 
 	public void saveAll(List<TransactionStatistic> transactionStatistics) {

--- a/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/domain/TransactionStatisticRepository.java
@@ -23,10 +23,6 @@ public class TransactionStatisticRepository {
 		return statisticJpaRepository.findCloseStatisticByStatisticDate(theDay);
 	}
 
-	public void save(TransactionStatistic transactionStatistic) {
-		statisticJpaRepository.save(transactionStatistic);
-	}
-
 	public void saveAll(List<TransactionStatistic> transactionStatistics) {
 		String sql = """
 			INSERT INTO transaction_statistic_zzamba (statistic_date, daily_total_amount, cumulative_amount)
@@ -38,5 +34,9 @@ public class TransactionStatisticRepository {
 			ps.setLong(2, statistic.getDailyTotalAmount());
 			ps.setLong(3, statistic.getCumulativeAmount());
 		});
+	}
+
+	public List<TransactionStatistic> findAll(Instant start, Instant end) {
+		return statisticJpaRepository.findByStatisticDateBetween(start, end);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/dto/TransactionStatisticResult.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/dto/TransactionStatisticResult.java
@@ -9,10 +9,10 @@ public record TransactionStatisticResult(LocalDate date,
 										 long cumulativeAmount) {
 
 	public static TransactionStatisticResult from(TransactionStatistic transactionStatistic) {
-		long epochSecond = transactionStatistic.getStatisticDate().getEpochSecond();
+		long epochDay = transactionStatistic.getStatisticDate().getEpochSecond() / (60L * 60L * 24L);
 
 		return new TransactionStatisticResult(
-			LocalDate.ofEpochDay(epochSecond),
+			LocalDate.ofEpochDay(epochDay),
 			transactionStatistic.getDailyTotalAmount(),
 			transactionStatistic.getCumulativeAmount()
 		);

--- a/src/main/java/org/c4marathon/assignment/statistic/dto/TransactionStatisticResult.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/dto/TransactionStatisticResult.java
@@ -1,0 +1,20 @@
+package org.c4marathon.assignment.statistic.dto;
+
+import java.time.LocalDate;
+
+import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
+
+public record TransactionStatisticResult(LocalDate date,
+										 long dayAmount,
+										 long cumulativeAmount) {
+
+	public static TransactionStatisticResult from(TransactionStatistic transactionStatistic) {
+		long epochSecond = transactionStatistic.getStatisticDate().getEpochSecond();
+
+		return new TransactionStatisticResult(
+			LocalDate.ofEpochDay(epochSecond),
+			transactionStatistic.getDailyTotalAmount(),
+			transactionStatistic.getCumulativeAmount()
+		);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/dto/TransactionStatisticResult.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/dto/TransactionStatisticResult.java
@@ -1,18 +1,15 @@
 package org.c4marathon.assignment.statistic.dto;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
 
-public record TransactionStatisticResult(LocalDate date,
-										 long dayAmount,
-										 long cumulativeAmount) {
+public record TransactionStatisticResult(LocalDate date, long dayAmount, long cumulativeAmount) {
 
 	public static TransactionStatisticResult from(TransactionStatistic transactionStatistic) {
-		long epochDay = transactionStatistic.getStatisticDate().getEpochSecond() / (60L * 60L * 24L);
-
 		return new TransactionStatisticResult(
-			LocalDate.ofEpochDay(epochDay),
+			LocalDate.ofInstant(transactionStatistic.getStatisticDate(), ZoneId.of("Z")),
 			transactionStatistic.getDailyTotalAmount(),
 			transactionStatistic.getCumulativeAmount()
 		);

--- a/src/main/java/org/c4marathon/assignment/statistic/infrastructure/TransactionStatisticJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/infrastructure/TransactionStatisticJpaRepository.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.statistic.infrastructure;
+
+import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionStatisticJpaRepository extends JpaRepository<TransactionStatistic, Long> {
+}

--- a/src/main/java/org/c4marathon/assignment/statistic/infrastructure/TransactionStatisticJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/infrastructure/TransactionStatisticJpaRepository.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.statistic.infrastructure;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
@@ -17,4 +18,6 @@ public interface TransactionStatisticJpaRepository extends JpaRepository<Transac
 		LIMIT 1
 	""", nativeQuery = true)
 	Optional<TransactionStatistic> findCloseStatisticByStatisticDate(Instant theDay);
+
+	List<TransactionStatistic> findByStatisticDateBetween(Instant start, Instant end);
 }

--- a/src/main/java/org/c4marathon/assignment/statistic/infrastructure/TransactionStatisticJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/statistic/infrastructure/TransactionStatisticJpaRepository.java
@@ -1,7 +1,20 @@
 package org.c4marathon.assignment.statistic.infrastructure;
 
+import java.time.Instant;
+import java.util.Optional;
+
 import org.c4marathon.assignment.statistic.domain.TransactionStatistic;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TransactionStatisticJpaRepository extends JpaRepository<TransactionStatistic, Long> {
+
+	@Query(value = """
+		SELECT *
+		FROM transaction_statistic_zzamba ts
+		WHERE ts.statistic_date <= :theDay
+		ORDER BY ts.statistic_date DESC
+		LIMIT 1
+	""", nativeQuery = true)
+	Optional<TransactionStatistic> findCloseStatisticByStatisticDate(Instant theDay);
 }

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/Transaction.java
@@ -1,0 +1,52 @@
+package org.c4marathon.assignment.transaction.domain;
+
+import java.time.Instant;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "transaction")
+public class Transaction {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "transaction_id", nullable = false)
+	private Integer id;
+
+	@Column(name = "sender_account", nullable = false, length = 20)
+	private String senderAccount;
+
+	@Column(name = "receiver_account", nullable = false, length = 20)
+	private String receiverAccount;
+
+	@Column(name = "sender_swift_code", nullable = false, length = 11)
+	private String senderSwiftCode;
+
+	@Column(name = "receiver_swift_code", nullable = false, length = 11)
+	private String receiverSwiftCode;
+
+	@Column(name = "sender_name", nullable = false, length = 30)
+	private String senderName;
+
+	@Column(name = "receiver_name", nullable = false, length = 30)
+	private String receiverName;
+
+	@Column(name = "amount", nullable = false)
+	private Long amount;
+
+	@Column(name = "memo", length = 200)
+	private String memo;
+
+	@ColumnDefault("CURRENT_TIMESTAMP")
+	@Column(name = "transaction_date", nullable = false)
+	private Instant transactionDate;
+
+}

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/TransactionRepository.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.transaction.domain;
+
+import org.c4marathon.assignment.transaction.infrastructure.TransactionJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TransactionRepository {
+	private final TransactionJpaRepository transactionJpaRepository;
+
+	public TransactionRepository(TransactionJpaRepository transactionJpaRepository) {
+		this.transactionJpaRepository = transactionJpaRepository;
+	}
+
+
+}

--- a/src/main/java/org/c4marathon/assignment/transaction/domain/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/domain/TransactionRepository.java
@@ -1,5 +1,9 @@
 package org.c4marathon.assignment.transaction.domain;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
 import org.c4marathon.assignment.transaction.infrastructure.TransactionJpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +15,19 @@ public class TransactionRepository {
 		this.transactionJpaRepository = transactionJpaRepository;
 	}
 
+	public Optional<Transaction> findFirstOrderByTransactionDate() {
+		return transactionJpaRepository.findFirstOrderByTransactionDate();
+	}
 
+	public List<Transaction> findBetweenTimesWithoutCursor(Instant startTime, Instant endTime, int limit) {
+		return transactionJpaRepository.findByTransactionDateBetween(startTime, endTime, limit);
+	}
+
+	public List<Transaction> findBetweenTimesWithCursor(Instant startTime, Instant endTime, Integer lastTransactionId, int limit) {
+		if (lastTransactionId == null) {
+			return findBetweenTimesWithoutCursor(startTime, endTime, limit);
+		}
+
+		return transactionJpaRepository.findByTransactionDateBetweenWithCursor(startTime, endTime, lastTransactionId, limit);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/transaction/infrastructure/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/infrastructure/TransactionJpaRepository.java
@@ -1,7 +1,37 @@
 package org.c4marathon.assignment.transaction.infrastructure;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
 import org.c4marathon.assignment.transaction.domain.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
+	@Query(value = """
+		SELECT *
+		FROM transaction t
+		ORDER BY t.transaction_date
+		LIMIT 1
+	""", nativeQuery = true)
+	Optional<Transaction> findFirstOrderByTransactionDate();
+
+	@Query(value = """
+		SELECT *
+		FROM transaction t
+		WHERE transaction_date >= :start AND transaction_date < :end
+		ORDER BY t.transaction_date
+		LIMIT :limit
+	""", nativeQuery = true)
+	List<Transaction> findByTransactionDateBetween(Instant start, Instant end, int limit);
+
+	@Query(value = """
+		SELECT *
+		FROM transaction t
+		WHERE (transaction_date > :start OR (transaction_date = :start AND transaction_id > :id)) AND transaction_date < :end
+		ORDER BY t.transaction_date
+		LIMIT :limit
+	""", nativeQuery = true)
+	List<Transaction> findByTransactionDateBetweenWithCursor(Instant start, Instant end, long id, int limit);
 }

--- a/src/main/java/org/c4marathon/assignment/transaction/infrastructure/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/infrastructure/TransactionJpaRepository.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.transaction.infrastructure;
+
+import org.c4marathon.assignment.transaction.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionJpaRepository extends JpaRepository<Transaction, Long> {
+}

--- a/src/main/java/org/c4marathon/assignment/transaction/infrastructure/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/transaction/infrastructure/TransactionJpaRepository.java
@@ -21,7 +21,7 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Lon
 		SELECT *
 		FROM transaction t
 		WHERE transaction_date >= :start AND transaction_date < :end
-		ORDER BY t.transaction_date
+		ORDER BY t.transaction_date, transaction_id
 		LIMIT :limit
 	""", nativeQuery = true)
 	List<Transaction> findByTransactionDateBetween(Instant start, Instant end, int limit);
@@ -30,7 +30,7 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Lon
 		SELECT *
 		FROM transaction t
 		WHERE (transaction_date > :start OR (transaction_date = :start AND transaction_id > :id)) AND transaction_date < :end
-		ORDER BY t.transaction_date
+		ORDER BY t.transaction_date, transaction_id
 		LIMIT :limit
 	""", nativeQuery = true)
 	List<Transaction> findByTransactionDateBetweenWithCursor(Instant start, Instant end, long id, int limit);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    url: jdbc:mysql://${DB_URL}/large-scale?socketTimeout=2000
+    url: jdbc:mysql://${DB_URL}/large-scale?socketTimeout=2000&serverTimezone=UTC
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       connection-timeout: 3000
@@ -13,7 +13,6 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
-    show-sql: true
 
 mail:
   email: ${MAIL_EMAIL}


### PR DESCRIPTION
집계 구현 방식은 다음과 같습니다.
1. 이미 집계된 통계가 있으면 그것을 반환.
2. 없으면 다음 중 하나를 수행
2-1. 바로 이전 통계 데이터를 가져와 누적 금액으로 저장, 통계 집계를 시작할 날짜를 설정.
2-2. 통계 데이터가 없다면 최초 트랜잭션 날짜를 집계 시작 날짜로 설정하고 누적 금액은 0으로 설정.
3. 집계 시작 시간부터 집계 끝 시간까지 6시간 단위로 분할, 각 시간 단위로 병렬 처리 및 벌크 연산
4. 모든 시간과 금액을 벌크 연산으로 삽입
* `/statistic/transaction/aggregate`로 통계 집계를 할 날짜를 정해 강제 집계가 가능합니다.
* `@Scheduled`를 통해 매 새벽 4시마다 한국 시간 기준 그 전날 통계를 집계합니다.

최대한 벌크 연산, 멀티스레드를 활용하여 통계 시간을 줄였습니다. 현재 데이터 기준 1분 안팎으로 전체 통계가 가능합니다.
### 이슈
`CustomThreadPoolExecutor`를 사용하려 했지만 자꾸 데이터가 안맞는 문제가 생겨서... 사용을 하지 않고 `Executors.newFixedThreadPool()`로 고정 스레드 풀을 생성해 그것을 이용하도록 했습니다. 그에 따라 에러는 없어졌습니다. 아직 이유를 찾지는 못했습니다.