### PR TITLE
Feature/hodadako step2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
     implementation 'org.apache.commons:commons-collections4:4.4'
+    implementation 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/c4marathon/assignment/domain/email_record/dto/SaveEmailRecordRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/email_record/dto/SaveEmailRecordRequest.java
@@ -8,19 +8,17 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
-public class EmailRecordRequest {
-	public record Save(
-		@NotNull
-		@Positive
-		Long memberId,
-		@NotBlank
-		String content,
-		@NotBlank
-		@Size(max = 50)
-		String subject
-	) {
-		public EmailRecord toEntity(Member member) {
-			return new EmailRecord(member, this.content, this.subject);
-		}
+public record SaveEmailRecordRequest(
+	@NotNull
+	@Positive
+	Long memberId,
+	@NotBlank
+	String content,
+	@NotBlank
+	@Size(max = 50)
+	String subject
+) {
+	public EmailRecord toEntity(Member member) {
+		return new EmailRecord(member, this.content, this.subject);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/email_record/presentation/EmailRecordController.java
+++ b/src/main/java/org/c4marathon/assignment/domain/email_record/presentation/EmailRecordController.java
@@ -2,7 +2,7 @@ package org.c4marathon.assignment.domain.email_record.presentation;
 
 import java.net.URI;
 
-import org.c4marathon.assignment.domain.email_record.dto.EmailRecordRequest;
+import org.c4marathon.assignment.domain.email_record.dto.SaveEmailRecordRequest;
 import org.c4marathon.assignment.domain.email_record.entity.EmailRecord;
 import org.c4marathon.assignment.domain.email_record.service.EmailRecordService;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,7 +25,7 @@ public class EmailRecordController {
 	private String baseUrl;
 
 	@PostMapping("/v1/email-records")
-	public ResponseEntity<EmailRecord> saveEmailRecord(@Valid EmailRecordRequest.Save request) {
+	public ResponseEntity<EmailRecord> saveEmailRecord(@Valid SaveEmailRecordRequest request) {
 		EmailRecord saved = emailRecordService.save(request);
 		URI uri = UriComponentsBuilder.fromUriString(baseUrl + saved.getId())
 			.build()

--- a/src/main/java/org/c4marathon/assignment/domain/email_record/repository/EmailRecordRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/email_record/repository/EmailRecordRepository.java
@@ -19,7 +19,7 @@ public interface EmailRecordRepository extends JpaRepository<EmailRecord, Long> 
 		"""
 			SELECT new org.c4marathon.assignment.domain.email_record.query.EmailRecordQueryResult(er.id, er.member.email, er.subject, er.content) 
 			FROM EmailRecord er 
-			LEFT JOIN FETCH er.member
+			LEFT JOIN er.member
 			WHERE er.emailStatus =:status
 			ORDER BY er.id ASC
 			""")

--- a/src/main/java/org/c4marathon/assignment/domain/email_record/service/EmailRecordService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/email_record/service/EmailRecordService.java
@@ -2,11 +2,7 @@ package org.c4marathon.assignment.domain.email_record.service;
 
 import static org.c4marathon.assignment.common.configuration.AsyncConfig.*;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import org.c4marathon.assignment.domain.email_record.dto.EmailRecordRequest;
+import org.c4marathon.assignment.domain.email_record.dto.SaveEmailRecordRequest;
 import org.c4marathon.assignment.domain.email_record.entity.EmailRecord;
 import org.c4marathon.assignment.domain.email_record.event.EmailRecordEvent;
 import org.c4marathon.assignment.domain.email_record.query.EmailRecordQueryResult;
@@ -30,7 +26,7 @@ public class EmailRecordService {
 	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
-	public EmailRecord save(EmailRecordRequest.Save request) {
+	public EmailRecord save(SaveEmailRecordRequest request) {
 		var member = memberReader.find(request.memberId());
 		return emailRecordStore.store(request.toEntity(member));
 	}

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
@@ -24,7 +24,7 @@ public class Transaction {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "transaction_id") // 여기서 컬럼명을 "transaction_id"로 변경
-	private Long id;
+	private Integer id;
 
 	@Column(name = "sender_account", columnDefinition = "varchar(20)", nullable = false)
 	private String senderAccount;

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
@@ -1,30 +1,50 @@
 package org.c4marathon.assignment.domain.transaction.entity;
 
-import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.c4marathon.assignment.common.entity.BaseEntity;
+import org.hibernate.annotations.ColumnDefault;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "transaction_hodadako")
+@Table(name = "transaction", indexes = {})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Transaction extends BaseEntity {
-	@Enumerated(EnumType.STRING)
-	@Column(name = "transaction_type", columnDefinition = "varchar(20)")
-	private TransactionType transactionType;
+	@Column(name = "sender_account", columnDefinition = "varchar(20)", nullable = false)
+	private String senderAccount;
 
-	@Column(name = "amount", columnDefinition = "decimal(15, 2)")
-	private BigDecimal amount;
+	@Column(name = "receiver_account", columnDefinition = "varchar(20)", nullable = false)
+	private String receiverAccount;
+
+	@Column(name = "sender_swift_code", columnDefinition = "varchar(11)", nullable = false)
+	private String senderSwiftCode;
+
+	@Column(name = "receiver_swift_code", columnDefinition = "varchar(11)", nullable = false)
+	private String receiverSwiftCode;
+
+	@Column(name = "sender_name", columnDefinition = "varchar(30)", nullable = false)
+	private String senderName;
+
+	@Column(name = "receiver_name", columnDefinition = "varchar(30)", nullable = false)
+	private String receiverName;
+
+	@Column(name = "amount", nullable = false)
+	private Long amount;
+
+	@Column(name = "memo", columnDefinition = "varchar(200)")
+	private String memo;
+
+	@ColumnDefault("CURRENT_TIMESTAMP")
+	@Column(name = "transaction_date", nullable = false)
+	private LocalDateTime transactionDate;
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
@@ -1,0 +1,41 @@
+package org.c4marathon.assignment.domain.transaction.entity;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import org.c4marathon.assignment.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "transaction_hodadako")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Transaction extends BaseEntity {
+	@Enumerated(EnumType.STRING)
+	@Column(name = "transaction_type", columnDefinition = "varchar(20)")
+	private TransactionType transactionType;
+
+	@Column(name = "amount", columnDefinition = "decimal(15, 2)")
+	private BigDecimal amount;
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof Transaction t) {
+			return this.getId() == t.getId();
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/entity/Transaction.java
@@ -8,6 +8,9 @@ import org.hibernate.annotations.ColumnDefault;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +20,12 @@ import lombok.NoArgsConstructor;
 @Table(name = "transaction", indexes = {})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Transaction extends BaseEntity {
+public class Transaction {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "transaction_id") // 여기서 컬럼명을 "transaction_id"로 변경
+	private Long id;
+
 	@Column(name = "sender_account", columnDefinition = "varchar(20)", nullable = false)
 	private String senderAccount;
 

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/entity/TransactionType.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/entity/TransactionType.java
@@ -1,0 +1,5 @@
+package org.c4marathon.assignment.domain.transaction.entity;
+
+public enum TransactionType {
+	TRANSFER
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionReader.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionReader.java
@@ -3,8 +3,7 @@ package org.c4marathon.assignment.domain.transaction.repository;
 import java.time.LocalDate;
 import java.util.stream.Stream;
 
-import org.c4marathon.assignment.domain.transaction.entity.Transaction;
-import org.c4marathon.assignment.domain.transaction.entity.TransactionType;
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class TransactionReader {
 	private final TransactionRepository transactionRepository;
 
-	public Stream<Transaction> findAllTransfersByDate(LocalDate date) {
-		return transactionRepository.findAllTransactionByTransactionTypeAndCreatedDate(TransactionType.TRANSFER, date);
+	public Stream<TransferStatistics> findTransferStatisticsBetweeen(LocalDate from, LocalDate to) {
+		return transactionRepository.findTransactionBetween(from, to);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionReader.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionReader.java
@@ -1,6 +1,6 @@
 package org.c4marathon.assignment.domain.transaction.repository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.c4marathon.assignment.domain.transaction.entity.Transaction;
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 public class TransactionReader {
 	private final TransactionRepository transactionRepository;
 
-	public Stream<Transaction> findAllTransfersByDate(LocalDateTime date) {
+	public Stream<Transaction> findAllTransfersByDate(LocalDate date) {
 		return transactionRepository.findAllTransactionByTransactionTypeAndCreatedDate(TransactionType.TRANSFER, date);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionReader.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionReader.java
@@ -1,0 +1,20 @@
+package org.c4marathon.assignment.domain.transaction.repository;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import org.c4marathon.assignment.domain.transaction.entity.Transaction;
+import org.c4marathon.assignment.domain.transaction.entity.TransactionType;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TransactionReader {
+	private final TransactionRepository transactionRepository;
+
+	public Stream<Transaction> findAllTransfersByDate(LocalDateTime date) {
+		return transactionRepository.findAllTransactionByTransactionTypeAndCreatedDate(TransactionType.TRANSFER, date);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionRepository.java
@@ -1,6 +1,6 @@
 package org.c4marathon.assignment.domain.transaction.repository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.c4marathon.assignment.domain.transaction.entity.Transaction;
@@ -14,5 +14,5 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 			SELECT t FROM Transaction t 
 			WHERE t.transactionType = :type AND t.createdDate = :date
 			""")
-	Stream<Transaction> findAllTransactionByTransactionTypeAndCreatedDate(TransactionType type, LocalDateTime date);
+	Stream<Transaction> findAllTransactionByTransactionTypeAndCreatedDate(TransactionType type, LocalDate date);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionRepository.java
@@ -1,0 +1,18 @@
+package org.c4marathon.assignment.domain.transaction.repository;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import org.c4marathon.assignment.domain.transaction.entity.Transaction;
+import org.c4marathon.assignment.domain.transaction.entity.TransactionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+	@Query(
+		"""
+			SELECT t FROM Transaction t 
+			WHERE t.transactionType = :type AND t.createdDate = :date
+			""")
+	Stream<Transaction> findAllTransactionByTransactionTypeAndCreatedDate(TransactionType type, LocalDateTime date);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transaction/repository/TransactionRepository.java
@@ -4,15 +4,21 @@ import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.c4marathon.assignment.domain.transaction.entity.Transaction;
-import org.c4marathon.assignment.domain.transaction.entity.TransactionType;
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 	@Query(
 		"""
-			SELECT t FROM Transaction t 
-			WHERE t.transactionType = :type AND t.createdDate = :date
+			SELECT new TransferStatistics(SUM(t.amount), 
+			SUM(SUM(t.amount)) OVER (ORDER BY DATE(t.transactionDate)), t.transactionDate) 
+			FROM Transaction t
+			WHERE t.transactionDate BETWEEN :startDate AND :endDate
+			GROUP BY t.transactionDate
+			ORDER BY t.transactionDate DESC
 			""")
-	Stream<Transaction> findAllTransactionByTransactionTypeAndCreatedDate(TransactionType type, LocalDate date);
+	Stream<TransferStatistics> findTransactionBetween(@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/dto/AggregateTransferStatisticsRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/dto/AggregateTransferStatisticsRequest.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PastOrPresent;
 
-public record GetTransferStatisticsRequest(
+public record AggregateTransferStatisticsRequest(
 	@NotBlank
 	@PastOrPresent
 	LocalDateTime targetDate

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/dto/GetAllTransferStatisticsRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/dto/GetAllTransferStatisticsRequest.java
@@ -1,0 +1,21 @@
+package org.c4marathon.assignment.domain.transfer_statistics.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Past;
+
+public record GetAllTransferStatisticsRequest(
+	@NotBlank
+	@Past
+	LocalDate startDate,
+	@NotBlank
+	@Past
+	LocalDate endDate
+) {
+	@AssertTrue(message = "시작 날짜는 종료 날짜보다 이전이어야 합니다.")
+	public boolean isStartDateBeforeEndDate() {
+		return startDate.isBefore(endDate);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/dto/GetTransferStatisticsRequest.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/dto/GetTransferStatisticsRequest.java
@@ -1,0 +1,13 @@
+package org.c4marathon.assignment.domain.transfer_statistics.dto;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PastOrPresent;
+
+public record GetTransferStatisticsRequest(
+	@NotBlank
+	@PastOrPresent
+	LocalDateTime targetDate
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/entity/TransferStatistics.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/entity/TransferStatistics.java
@@ -3,8 +3,10 @@ package org.c4marathon.assignment.domain.transfer_statistics.entity;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.c4marathon.assignment.common.entity.BaseEntity;
+import org.c4marathon.assignment.domain.transaction.entity.Transaction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,6 +28,14 @@ public class TransferStatistics extends BaseEntity {
 
 	@Column(name = "unit_date", columnDefinition = "timestamp")
 	private LocalDateTime unitDate;
+
+	public TransferStatistics(Stream<Transaction> transactions, TransferStatistics transferStatistics) {
+		BigDecimal currentDailyTotal = transactions.map(Transaction::getAmount)
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+		BigDecimal previousCumulativeTotal = transferStatistics.getCumulativeTotalAmount();
+		this.dailyTotalAmount = currentDailyTotal;
+		this.cumulativeTotalAmount = previousCumulativeTotal.add(currentDailyTotal);
+	}
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/entity/TransferStatistics.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/entity/TransferStatistics.java
@@ -1,12 +1,9 @@
 package org.c4marathon.assignment.domain.transfer_statistics.entity;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.c4marathon.assignment.common.entity.BaseEntity;
-import org.c4marathon.assignment.domain.transaction.entity.Transaction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,21 +17,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TransferStatistics extends BaseEntity {
-	@Column(name = "daily_total_amount", columnDefinition = "decimal(15, 2)")
-	private BigDecimal dailyTotalAmount;
+	@Column(name = "daily_total_amount", columnDefinition = "bigint")
+	private Long dailyTotalAmount;
 
-	@Column(name = "cumulative_total_amount", columnDefinition = "decimal(15, 2)")
-	private BigDecimal cumulativeTotalAmount;
+	@Column(name = "cumulative_total_amount", columnDefinition = "bigint")
+	private Long cumulativeTotalAmount;
 
-	@Column(name = "unit_date", columnDefinition = "timestamp")
+	@Column(name = "unit_date", columnDefinition = "datetime")
 	private LocalDateTime unitDate;
 
-	public TransferStatistics(Stream<Transaction> transactions, TransferStatistics transferStatistics) {
-		BigDecimal currentDailyTotal = transactions.map(Transaction::getAmount)
-			.reduce(BigDecimal.ZERO, BigDecimal::add);
-		BigDecimal previousCumulativeTotal = transferStatistics.getCumulativeTotalAmount();
-		this.dailyTotalAmount = currentDailyTotal;
-		this.cumulativeTotalAmount = previousCumulativeTotal.add(currentDailyTotal);
+	public TransferStatistics(Long dailyTotalAmount, Long cumulativeTotalAmount, LocalDateTime unitDate) {
+		this.dailyTotalAmount = dailyTotalAmount;
+		this.cumulativeTotalAmount = cumulativeTotalAmount;
+		this.unitDate = unitDate;
 	}
 
 	@Override

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/entity/TransferStatistics.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/entity/TransferStatistics.java
@@ -1,0 +1,42 @@
+package org.c4marathon.assignment.domain.transfer_statistics.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import org.c4marathon.assignment.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "transfer_statistics_hodadako")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TransferStatistics extends BaseEntity {
+	@Column(name = "daily_total_amount", columnDefinition = "decimal(15, 2)")
+	private BigDecimal dailyTotalAmount;
+
+	@Column(name = "cumulative_total_amount", columnDefinition = "decimal(15, 2)")
+	private BigDecimal cumulativeTotalAmount;
+
+	@Column(name = "unit_date", columnDefinition = "timestamp")
+	private LocalDateTime unitDate;
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof TransferStatistics transferStatistics) {
+			return this.getId() == transferStatistics.getId();
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/presentation/TransferStatisticsController.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/presentation/TransferStatisticsController.java
@@ -1,0 +1,40 @@
+package org.c4marathon.assignment.domain.transfer_statistics.presentation;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.c4marathon.assignment.domain.transfer_statistics.dto.AggregateTransferStatisticsRequest;
+import org.c4marathon.assignment.domain.transfer_statistics.dto.GetAllTransferStatisticsRequest;
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
+import org.c4marathon.assignment.domain.transfer_statistics.service.TransferStatisticsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TransferStatisticsController {
+	private final TransferStatisticsService transferStatisticsService;
+
+	@GetMapping("/v1/transfer-statistics")
+	public ResponseEntity<List<TransferStatistics>> getTransferStatisticsInBetween(
+		@RequestParam(name = "start-date") LocalDate startDate, @RequestParam(name = "end-date") LocalDate endDate) {
+		return ResponseEntity.ok(
+			transferStatisticsService.findAllByUnitDateBetween(
+				new GetAllTransferStatisticsRequest(startDate, endDate)));
+	}
+
+	@PostMapping("/v1/transfer-statistics")
+	public ResponseEntity<TransferStatistics> aggregateTransferStatistics(
+		@RequestBody AggregateTransferStatisticsRequest request
+	) {
+		return ResponseEntity.ok(transferStatisticsService.getStatistics(request));
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsReader.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsReader.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.domain.transfer_statistics.repository;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TransferStatisticsReader {
+	private final TransferStatisticsRepository transferStatisticsRepository;
+
+	public Stream<TransferStatistics> findAllByUnitDateBetween(LocalDate from, LocalDate to) {
+		return transferStatisticsRepository.findAllByUnitDateBetween(from, to);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsReader.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsReader.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
 import org.springframework.stereotype.Component;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -15,5 +16,10 @@ public class TransferStatisticsReader {
 
 	public Stream<TransferStatistics> findAllByUnitDateBetween(LocalDate from, LocalDate to) {
 		return transferStatisticsRepository.findAllByUnitDateBetween(from, to);
+	}
+
+	public TransferStatistics findByUnitDate(LocalDate date) {
+		return transferStatisticsRepository.findByUnitDate(date)
+			.orElseThrow(() -> new EntityNotFoundException("해당 송금 통계는 존재하지 않습니다."));
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsRepository.java
@@ -1,0 +1,28 @@
+package org.c4marathon.assignment.domain.transfer_statistics.repository;
+
+import static org.hibernate.jpa.HibernateHints.*;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.QueryHint;
+
+public interface TransferStatisticsRepository extends JpaRepository<TransferStatistics, Long> {
+	@Query(
+		"""
+			SELECT ts FROM TransferStatistics ts
+			WHERE ts.unitDate between :startDate AND :endDate
+			ORDER BY ts.unitDate DESC
+			""")
+	@QueryHints(value = {
+		@QueryHint(name = HINT_FETCH_SIZE, value = "" + Integer.MAX_VALUE),
+		@QueryHint(name = HINT_CACHEABLE, value = "false"),
+	})
+	Stream<TransferStatistics> findAllByUnitDateBetween(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsRepository.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsRepository.java
@@ -3,6 +3,7 @@ package org.c4marathon.assignment.domain.transfer_statistics.repository;
 import static org.hibernate.jpa.HibernateHints.*;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
@@ -25,4 +26,6 @@ public interface TransferStatisticsRepository extends JpaRepository<TransferStat
 		@QueryHint(name = HINT_CACHEABLE, value = "false"),
 	})
 	Stream<TransferStatistics> findAllByUnitDateBetween(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+	Optional<TransferStatistics> findByUnitDate(LocalDate date);
 }

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsStore.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/repository/TransferStatisticsStore.java
@@ -1,0 +1,16 @@
+package org.c4marathon.assignment.domain.transfer_statistics.repository;
+
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TransferStatisticsStore {
+	private final TransferStatisticsRepository transferStatisticsRepository;
+
+	public TransferStatistics store(TransferStatistics transferStatistics) {
+		return transferStatisticsRepository.save(transferStatistics);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/service/TransferStatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/service/TransferStatisticsService.java
@@ -1,0 +1,56 @@
+package org.c4marathon.assignment.domain.transfer_statistics.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.c4marathon.assignment.domain.transaction.entity.Transaction;
+import org.c4marathon.assignment.domain.transaction.repository.TransactionReader;
+import org.c4marathon.assignment.domain.transfer_statistics.dto.GetTransferStatisticsRequest;
+import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
+import org.c4marathon.assignment.domain.transfer_statistics.repository.TransferStatisticsReader;
+import org.c4marathon.assignment.domain.transfer_statistics.repository.TransferStatisticsStore;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TransferStatisticsService {
+	private final TransferStatisticsReader transferStatisticsReader;
+	private final TransferStatisticsStore transferStatisticsStore;
+	private final TransactionReader transactionReader;
+
+	@Transactional(readOnly = true)
+	public List<TransferStatistics> findAllByUnitDateBetween(LocalDateTime startDate, LocalDateTime endDate) {
+		return transferStatisticsReader.findAllByUnitDateBetween(startDate.toLocalDate(), endDate.toLocalDate())
+			.toList();
+	}
+
+	@Scheduled(cron = "0 0 4 * * *")
+	@Transactional
+	public void getScheduledStatistics() {
+		var yesterday = LocalDateTime.now().minusDays(1).toLocalDate();
+		var allTransfersByDate = transactionReader.findAllTransfersByDate(yesterday);
+		var transferStatistics = transferStatisticsReader.findByUnitDate(yesterday);
+		transferStatisticsStore.store(new TransferStatistics(allTransfersByDate, transferStatistics));
+	}
+
+	@Transactional
+	public TransferStatistics getStatistics(GetTransferStatisticsRequest request) {
+		var targetDate = request.targetDate().toLocalDate();
+
+		var transferStatistics = transferStatisticsReader.findByUnitDate(targetDate);
+
+		if (transferStatistics != null) {
+			return transferStatistics;
+		}
+
+		var allTransfersByDate = transactionReader.findAllTransfersByDate(targetDate);
+		transferStatistics = transferStatisticsReader.findByUnitDate(targetDate.minusDays(1));
+		return transferStatisticsStore.store(new TransferStatistics(allTransfersByDate, transferStatistics));
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/service/TransferStatisticsService.java
+++ b/src/main/java/org/c4marathon/assignment/domain/transfer_statistics/service/TransferStatisticsService.java
@@ -1,13 +1,11 @@
 package org.c4marathon.assignment.domain.transfer_statistics.service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Stream;
 
-import org.c4marathon.assignment.domain.transaction.entity.Transaction;
 import org.c4marathon.assignment.domain.transaction.repository.TransactionReader;
-import org.c4marathon.assignment.domain.transfer_statistics.dto.GetTransferStatisticsRequest;
+import org.c4marathon.assignment.domain.transfer_statistics.dto.GetAllTransferStatisticsRequest;
+import org.c4marathon.assignment.domain.transfer_statistics.dto.AggregateTransferStatisticsRequest;
 import org.c4marathon.assignment.domain.transfer_statistics.entity.TransferStatistics;
 import org.c4marathon.assignment.domain.transfer_statistics.repository.TransferStatisticsReader;
 import org.c4marathon.assignment.domain.transfer_statistics.repository.TransferStatisticsStore;
@@ -25,8 +23,8 @@ public class TransferStatisticsService {
 	private final TransactionReader transactionReader;
 
 	@Transactional(readOnly = true)
-	public List<TransferStatistics> findAllByUnitDateBetween(LocalDateTime startDate, LocalDateTime endDate) {
-		return transferStatisticsReader.findAllByUnitDateBetween(startDate.toLocalDate(), endDate.toLocalDate())
+	public List<TransferStatistics> findAllByUnitDateBetween(GetAllTransferStatisticsRequest request) {
+		return transferStatisticsReader.findAllByUnitDateBetween(request.startDate(), request.endDate())
 			.toList();
 	}
 
@@ -40,7 +38,7 @@ public class TransferStatisticsService {
 	}
 
 	@Transactional
-	public TransferStatistics getStatistics(GetTransferStatisticsRequest request) {
+	public TransferStatistics getStatistics(AggregateTransferStatisticsRequest request) {
 		var targetDate = request.targetDate().toLocalDate();
 
 		var transferStatistics = transferStatisticsReader.findByUnitDate(targetDate);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: org.mysql.cj.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   mail:
     host: ${SMTP_HOST}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
       mail.smtp.ssl.enable: true
       mail.smtp.ssl.trust: ${SMTP_HOST}
       mail.smtp.starttls.enable: true
+  jpa:
+    hibernate:
+      ddl-auto: update
 
 api:
   email-record:


### PR DESCRIPTION
## 구현사항

* 새로운 통계 테이블을 생성합니다.
* 일 단위 당일 전체 송금 금액, 해당 날짜 까지의 누적 송금 금액 을 담도록 작성해 주세요.
* 해당 테이블을 조회하는 API (시작 날짜와 종료 날짜를 받는) 도 개발이 필요합니다.
* 일반적인 경우 새벽 4시 에 전날 통계 집계가 진행되며, 필요 시 API를 통해 특정 날짜의 통계를 강제로 집계할 수 있어야 합니다.

## 구현내용
* Transaction에서 날짜 간 사이의 전체 송금 금액과 누적 송금 금액을 한번에 조회하도록 구현하였습니다.
* schedule 뿐만 아니라 강제로 집계할 수 있는 API를 추가하였습니다.

## 수정사항

* 기존 Entity들을 대용량 데이터 w / Backend에 맞게끔 수정했습니다. 
* Transaction 테이블이 존재하는걸 뒤늦게 알게되어 그에 맞추어 수정하였습니다.
