### PR TITLE
 Feature/nyh365 Step3: 사용자 전체 정보 조회

### DIFF
--- a/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
@@ -16,7 +16,7 @@ public class MarathonController {
 	private final MarathonService marathonService;
 
 	@GetMapping("/all-info")
-	public FinancialInfoRes getAllInfo(@RequestParam String email) {
-		return marathonService.getAllInfo(email);
+	public FinancialInfoRes getAllInfoWithLimit(@RequestParam String email) {
+		return marathonService.getAllInfoWithLimit(email);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
@@ -19,4 +19,9 @@ public class MarathonController {
 	public FinancialInfoRes getAllInfoWithLimit(@RequestParam String email) {
 		return marathonService.getAllInfoWithLimit(email);
 	}
+
+	@GetMapping("/all-info-not-parallel")
+	public FinancialInfoRes getAllInfoNotParallel(@RequestParam String email) {
+		return marathonService.getAllInfoNotParallel(email);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
@@ -1,0 +1,22 @@
+package org.c4marathon.assignment.controller;
+
+import org.c4marathon.assignment.dto.response.FinancialInfoRes;
+import org.c4marathon.assignment.service.MarathonService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/marathon")
+@RequiredArgsConstructor
+public class MarathonController {
+	private final MarathonService marathonService;
+
+	@GetMapping("/all-info")
+	public FinancialInfoRes getAllInfo(@RequestParam String email) {
+		return marathonService.getAllInfo(email);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
+++ b/src/main/java/org/c4marathon/assignment/controller/MarathonController.java
@@ -16,12 +16,12 @@ public class MarathonController {
 	private final MarathonService marathonService;
 
 	@GetMapping("/all-info")
-	public FinancialInfoRes getAllInfoWithLimit(@RequestParam String email) {
-		return marathonService.getAllInfoWithLimit(email);
+	public FinancialInfoRes getAllInfoWithLimit(@RequestParam Integer id) {
+		return marathonService.getAllInfoWithLimit(id);
 	}
 
 	@GetMapping("/all-info-not-parallel")
-	public FinancialInfoRes getAllInfoNotParallel(@RequestParam String email) {
-		return marathonService.getAllInfoNotParallel(email);
+	public FinancialInfoRes getAllInfoNotParallel(@RequestParam Integer id) {
+		return marathonService.getAllInfoNotParallel(id);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/core/C4ThreadPoolExecutor.java
+++ b/src/main/java/org/c4marathon/assignment/core/C4ThreadPoolExecutor.java
@@ -1,0 +1,78 @@
+package org.c4marathon.assignment.core;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class C4ThreadPoolExecutor implements Executor {
+	private final int threadCount;
+	private final int queueSize;
+	private ThreadPoolExecutor threadPoolExecutor;
+	private RuntimeException exception = null;
+
+	public void init() {
+		if (threadPoolExecutor != null) {
+			return;
+		}
+
+		threadPoolExecutor = new ThreadPoolExecutor(threadCount, threadCount, 0L, TimeUnit.MILLISECONDS,
+			new LinkedBlockingQueue<>(queueSize),
+			(r, executor) -> {
+				try {
+					executor.getQueue().put(r);
+				} catch (InterruptedException e) {
+					log.error(e.toString(), e);
+					Thread.currentThread().interrupt();
+				}
+			});
+	}
+
+	@Override
+	public void execute(Runnable command) {
+		if (isInvalidState()) {
+			return;
+		}
+
+		threadPoolExecutor.execute(() -> {
+			try {
+				command.run();
+			} catch (RuntimeException e) {
+				log.error(e.toString(), e);
+				exception = e;
+			}
+		});
+	}
+
+	public void waitToEnd() {
+		if (isInvalidState()) {
+			return;
+		}
+
+		threadPoolExecutor.shutdown();
+		while (true) {
+			try {
+				if (threadPoolExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)) {
+					break;
+				}
+			} catch (InterruptedException e) {
+				log.error(e.toString(), e);
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		threadPoolExecutor = null;
+		if (exception != null) {
+			throw exception;
+		}
+	}
+
+	private boolean isInvalidState() {
+		return threadPoolExecutor == null || threadPoolExecutor.isTerminating() || threadPoolExecutor.isTerminated();
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/dto/response/AccountRes.java
+++ b/src/main/java/org/c4marathon/assignment/dto/response/AccountRes.java
@@ -1,0 +1,15 @@
+package org.c4marathon.assignment.dto.response;
+
+import org.c4marathon.assignment.entity.Account;
+
+public record AccountRes(
+	String accountNumber,
+	Long balance
+) {
+	public AccountRes(Account account) {
+		this(
+			account.getAccountNumber(),
+			account.getBalance()
+		);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/dto/response/FinancialInfoRes.java
+++ b/src/main/java/org/c4marathon/assignment/dto/response/FinancialInfoRes.java
@@ -1,0 +1,19 @@
+package org.c4marathon.assignment.dto.response;
+
+import java.util.List;
+
+public record FinancialInfoRes(
+	List<AccountRes> accountRes,
+	List<TransactionRes> transactionRes,
+	int accountTotal,
+	int transactionTotal
+) {
+	public FinancialInfoRes(List<AccountRes> accountRes, List<TransactionRes> transactionRes) {
+		this(
+			accountRes,
+			transactionRes,
+			accountRes.size(),
+			transactionRes.size()
+		);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/dto/response/TransactionRes.java
+++ b/src/main/java/org/c4marathon/assignment/dto/response/TransactionRes.java
@@ -1,0 +1,31 @@
+package org.c4marathon.assignment.dto.response;
+
+import java.time.Instant;
+
+import org.c4marathon.assignment.entity.Transaction;
+
+public record TransactionRes(
+	String senderAccount,
+	String receiverAccount,
+	String senderSwiftCode,
+	String receiverSwiftCode,
+	String senderName,
+	String receiverName,
+	Long amount,
+	String memo,
+	Instant transactionDate
+) {
+	public TransactionRes(Transaction transaction) {
+		this(
+			transaction.getSenderAccount(),
+			transaction.getReceiverAccount(),
+			transaction.getSenderSwiftCode(),
+			transaction.getReceiverSwiftCode(),
+			transaction.getSenderName(),
+			transaction.getReceiverName(),
+			transaction.getAmount(),
+			transaction.getMemo(),
+			transaction.getTransactionDate()
+		);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/entity/Account.java
+++ b/src/main/java/org/c4marathon/assignment/entity/Account.java
@@ -1,0 +1,67 @@
+package org.c4marathon.assignment.entity;
+
+import java.time.Instant;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "account")
+public class Account {
+	public static final String ACCOUNT_PREFIX = "3333";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "account_id", nullable = false)
+	private Integer id;
+
+	@Size(max = 13)
+	@NotNull
+	@Column(name = "account_number", nullable = false, length = 13)
+	private String accountNumber;
+
+	@NotNull
+	@Column(name = "user_id", nullable = false)
+	private Integer userId;
+
+	@NotNull
+	@Column(name = "account_type", nullable = false)
+	private Character accountType;
+
+	@Size(max = 200)
+	@Column(name = "memo", length = 200)
+	private String memo;
+
+	@NotNull
+	@ColumnDefault("0")
+	@Column(name = "balance", nullable = false)
+	private Long balance;
+
+	@NotNull
+	@ColumnDefault("CURRENT_TIMESTAMP")
+	@Column(name = "create_date", nullable = false)
+	private Instant createDate;
+
+	@Column(name = "recent_transaction_date")
+	private Instant recentTransactionDate;
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/entity/User.java
+++ b/src/main/java/org/c4marathon/assignment/entity/User.java
@@ -1,0 +1,54 @@
+package org.c4marathon.assignment.entity;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "user")
+public class User {
+	@Id
+	@Column(name = "user_id", nullable = false)
+	private Integer id;
+
+	@Size(max = 30)
+	@NotNull
+	@Column(name = "username", nullable = false, length = 30)
+	private String username;
+
+	@Size(max = 30)
+	@NotNull
+	@Column(name = "email", nullable = false, length = 30)
+	private String email;
+
+	@Size(max = 10)
+	@NotNull
+	@Column(name = "nickname", nullable = false, length = 10)
+	private String nickname;
+
+	@NotNull
+	@Column(name = "group_id", nullable = false)
+	private Integer groupId;
+
+	@NotNull
+	@Column(name = "user_status", nullable = false)
+	private Character userStatus;
+
+	@NotNull
+	@Column(name = "create_date", nullable = false)
+	private Instant createDate;
+
+	@NotNull
+	@Column(name = "update_date", nullable = false)
+	private Instant updateDate;
+
+}

--- a/src/main/java/org/c4marathon/assignment/exception/BadRequestException.java
+++ b/src/main/java/org/c4marathon/assignment/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package org.c4marathon.assignment.exception;
+
+public class BadRequestException extends RuntimeException {
+	public BadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/c4marathon/assignment/handler/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package org.c4marathon.assignment.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.c4marathon.assignment.exception.BadRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+	private static final String MESSAGE = "message";
+
+	@ExceptionHandler(BadRequestException.class)
+	public ResponseEntity<Map<String, Object>> handleBadRequestException(BadRequestException ex) {
+		Map<String, Object> resultMap = new HashMap<>();
+
+		resultMap.put(MESSAGE, ex.getMessage());
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(resultMap);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/repository/AccountJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/AccountJpaRepository.java
@@ -1,0 +1,12 @@
+package org.c4marathon.assignment.repository;
+
+import java.util.List;
+
+import org.c4marathon.assignment.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountJpaRepository extends JpaRepository<Account, Long> {
+	List<Account> findAllByUserId(Integer userId);
+}

--- a/src/main/java/org/c4marathon/assignment/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/AccountRepository.java
@@ -1,0 +1,18 @@
+package org.c4marathon.assignment.repository;
+
+import java.util.List;
+
+import org.c4marathon.assignment.entity.Account;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AccountRepository {
+	private final AccountJpaRepository accountJpaRepository;
+
+	public List<Account> findAllAccountByUserId(Integer userId) {
+		return accountJpaRepository.findAllByUserId(userId);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionJpaRepository.java
@@ -31,4 +31,26 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Lon
 		OR t.receiverAccount = :account
 		""")
 	List<Transaction> findAllTransaction(@Param("account") String account);
+
+	@Query("""
+		SELECT t
+		FROM Transaction t
+		WHERE (t.receiverAccount = :account OR t.senderAccount = :account)
+		AND t.id > :lastId
+		ORDER BY t.id
+		LIMIT :limit
+		""")
+	List<Transaction> findTransactionByAccountNumberAndLastTransactionId(@Param("account") String accountNumber,
+		@Param("lastId") Integer lastTransactionId,
+		@Param("limit") int limit);
+
+	@Query("""
+		SELECT t
+		FROM Transaction t
+		WHERE t.receiverAccount = :account OR t.senderAccount = :account
+		ORDER BY t.id
+		LIMIT :limit
+		""")
+	List<Transaction> findTransaction(@Param("account") String accountNumber,
+		@Param("limit") int limit);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionJpaRepository.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.repository;
 
 import java.time.Instant;
+import java.util.List;
 
 import org.c4marathon.assignment.entity.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,11 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Lon
 					  			)
 		""")
 	Long cumulativeRemittanceBeforeDate(@Param("date") Instant date);
+
+	@Query("""
+		SELECT t
+		FROM Transaction t WHERE t.senderAccount = :account 
+		OR t.receiverAccount = :account
+		""")
+	List<Transaction> findAllTransaction(@Param("account") String account);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
@@ -1,7 +1,9 @@
 package org.c4marathon.assignment.repository;
 
 import java.time.Instant;
+import java.util.List;
 
+import org.c4marathon.assignment.entity.Transaction;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -17,5 +19,9 @@ public class TransactionRepository {
 
 	public Long cumulativeRemittanceBeforeDate(Instant instantDate) {
 		return transactionJpaRepository.cumulativeRemittanceBeforeDate(instantDate);
+	}
+
+	public List<Transaction> findAllTransaction(String account) {
+		return transactionJpaRepository.findAllTransaction(account);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/TransactionRepository.java
@@ -24,4 +24,14 @@ public class TransactionRepository {
 	public List<Transaction> findAllTransaction(String account) {
 		return transactionJpaRepository.findAllTransaction(account);
 	}
+
+	public List<Transaction> findTransactionByAccountNumberAndLastTransactionId(String accountNumber,
+		Integer lastTransactionId, int limit) {
+		if (lastTransactionId == null) {
+			return transactionJpaRepository.findTransaction(accountNumber, limit);
+		}
+
+		return transactionJpaRepository.findTransactionByAccountNumberAndLastTransactionId(accountNumber,
+			lastTransactionId, limit);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/repository/UserJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/UserJpaRepository.java
@@ -6,5 +6,5 @@ import org.c4marathon.assignment.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
-	Optional<User> findByEmail(String email);
+	Optional<User> findById(Integer id);
 }

--- a/src/main/java/org/c4marathon/assignment/repository/UserJpaRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package org.c4marathon.assignment.repository;
+
+import java.util.Optional;
+
+import org.c4marathon.assignment.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+	Optional<User> findByEmail(String email);
+}

--- a/src/main/java/org/c4marathon/assignment/repository/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package org.c4marathon.assignment.repository;
+
+import java.util.Optional;
+
+import org.c4marathon.assignment.entity.User;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepository {
+	private final UserJpaRepository userJpaRepository;
+
+	public Optional<User> findUserByEmail(String email) {
+		return userJpaRepository.findByEmail(email);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/repository/UserRepository.java
+++ b/src/main/java/org/c4marathon/assignment/repository/UserRepository.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 public class UserRepository {
 	private final UserJpaRepository userJpaRepository;
 
-	public Optional<User> findUserByEmail(String email) {
-		return userJpaRepository.findByEmail(email);
+	public Optional<User> findUserById(Integer id) {
+		return userJpaRepository.findById(id);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/service/MarathonService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MarathonService.java
@@ -1,5 +1,6 @@
 package org.c4marathon.assignment.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -8,11 +9,13 @@ import java.util.concurrent.Executor;
 import org.c4marathon.assignment.dto.response.AccountRes;
 import org.c4marathon.assignment.dto.response.FinancialInfoRes;
 import org.c4marathon.assignment.dto.response.TransactionRes;
+import org.c4marathon.assignment.entity.Transaction;
 import org.c4marathon.assignment.entity.User;
 import org.c4marathon.assignment.exception.BadRequestException;
 import org.c4marathon.assignment.repository.AccountRepository;
 import org.c4marathon.assignment.repository.TransactionRepository;
 import org.c4marathon.assignment.repository.UserRepository;
+import org.c4marathon.assignment.util.C4QueryExecuteTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -20,12 +23,13 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MarathonService {
+	public static final int LIMIT_SIZE = 1000;
 	private final UserRepository userRepository;
 	private final AccountRepository accountRepository;
 	private final Executor asyncTaskExecutor;
 	private final TransactionRepository transactionRepository;
 
-	public FinancialInfoRes getAllInfo(String email) {
+	public FinancialInfoRes getAllInfoWithLimit(String email) {
 		User user = userRepository.findUserByEmail(email)
 			.orElseThrow(() -> new BadRequestException("존재하지 않는 회원입니다."));
 
@@ -33,12 +37,19 @@ public class MarathonService {
 			.stream().map(AccountRes::new).toList();
 
 		List<CompletableFuture<List<TransactionRes>>> futures = accountResList.stream()
-			.map(accountRes -> CompletableFuture.supplyAsync(() ->
-					transactionRepository.findAllTransaction(accountRes.accountNumber())
-						.stream()
-						.map(TransactionRes::new)
-						.toList(),
-				asyncTaskExecutor))
+			.map(accountRes -> CompletableFuture.supplyAsync(() -> {
+				List<TransactionRes> transactionResList = new ArrayList<>();
+
+				C4QueryExecuteTemplate.<Transaction>selectAndExecuteWithCursor(LIMIT_SIZE,
+					lastTransaction -> transactionRepository.findTransactionByAccountNumberAndLastTransactionId(
+						accountRes.accountNumber(), lastTransaction == null ? null : lastTransaction.getId(),
+						LIMIT_SIZE),
+					transactions -> transactionResList.addAll(
+						transactions.stream().map(TransactionRes::new).toList())
+				);
+
+				return transactionResList;
+			}, asyncTaskExecutor))
 			.toList();
 
 		List<TransactionRes> transactions = futures.stream()

--- a/src/main/java/org/c4marathon/assignment/service/MarathonService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MarathonService.java
@@ -2,8 +2,6 @@ package org.c4marathon.assignment.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import org.c4marathon.assignment.core.C4ThreadPoolExecutor;
@@ -29,7 +27,6 @@ public class MarathonService {
 	public static final int MAX_POOL_SIZE = 32;
 	private final UserRepository userRepository;
 	private final AccountRepository accountRepository;
-	private final Executor asyncTaskExecutor;
 	private final TransactionRepository transactionRepository;
 	private final C4ThreadPoolExecutor threadPoolExecutor = new C4ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE);
 

--- a/src/main/java/org/c4marathon/assignment/service/MarathonService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MarathonService.java
@@ -2,8 +2,6 @@ package org.c4marathon.assignment.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.Executor;
 
 import org.c4marathon.assignment.core.C4ThreadPoolExecutor;
 import org.c4marathon.assignment.dto.response.AccountRes;

--- a/src/main/java/org/c4marathon/assignment/service/MarathonService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MarathonService.java
@@ -31,8 +31,8 @@ public class MarathonService {
 	private final TransactionRepository transactionRepository;
 	private final C4ThreadPoolExecutor threadPoolExecutor = new C4ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE);
 
-	public FinancialInfoRes getAllInfoWithLimit(String email) {
-		User user = userRepository.findUserByEmail(email)
+	public FinancialInfoRes getAllInfoWithLimit(Integer userId) {
+		User user = userRepository.findUserById(userId)
 			.orElseThrow(() -> new BadRequestException("존재하지 않는 회원입니다."));
 
 		List<AccountRes> accountResList = accountRepository.findAllAccountByUserId(user.getId())
@@ -57,8 +57,8 @@ public class MarathonService {
 		return new FinancialInfoRes(accountResList, transactionResList);
 	}
 
-	public FinancialInfoRes getAllInfoNotParallel(String email) {
-		User user = userRepository.findUserByEmail(email)
+	public FinancialInfoRes getAllInfoNotParallel(Integer userId) {
+		User user = userRepository.findUserById(userId)
 			.orElseThrow(() -> new BadRequestException("존재하지 않는 회원입니다."));
 
 		List<AccountRes> accountResList = accountRepository.findAllAccountByUserId(user.getId())

--- a/src/main/java/org/c4marathon/assignment/service/MarathonService.java
+++ b/src/main/java/org/c4marathon/assignment/service/MarathonService.java
@@ -1,0 +1,52 @@
+package org.c4marathon.assignment.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.c4marathon.assignment.dto.response.AccountRes;
+import org.c4marathon.assignment.dto.response.FinancialInfoRes;
+import org.c4marathon.assignment.dto.response.TransactionRes;
+import org.c4marathon.assignment.entity.User;
+import org.c4marathon.assignment.exception.BadRequestException;
+import org.c4marathon.assignment.repository.AccountRepository;
+import org.c4marathon.assignment.repository.TransactionRepository;
+import org.c4marathon.assignment.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MarathonService {
+	private final UserRepository userRepository;
+	private final AccountRepository accountRepository;
+	private final Executor asyncTaskExecutor;
+	private final TransactionRepository transactionRepository;
+
+	public FinancialInfoRes getAllInfo(String email) {
+		User user = userRepository.findUserByEmail(email)
+			.orElseThrow(() -> new BadRequestException("존재하지 않는 회원입니다."));
+
+		List<AccountRes> accountResList = accountRepository.findAllAccountByUserId(user.getId())
+			.stream().map(AccountRes::new).toList();
+
+		List<CompletableFuture<List<TransactionRes>>> futures = accountResList.stream()
+			.map(accountRes -> CompletableFuture.supplyAsync(() ->
+					transactionRepository.findAllTransaction(accountRes.accountNumber())
+						.stream()
+						.map(TransactionRes::new)
+						.toList(),
+				asyncTaskExecutor))
+			.toList();
+
+		List<TransactionRes> transactions = futures.stream()
+			.map(CompletableFuture::join)
+			.filter(Objects::nonNull)
+			.flatMap(List::stream)
+			.toList();
+
+		return new FinancialInfoRes(accountResList, transactions);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/util/C4QueryExecuteTemplate.java
+++ b/src/main/java/org/c4marathon/assignment/util/C4QueryExecuteTemplate.java
@@ -1,0 +1,26 @@
+package org.c4marathon.assignment.util;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class C4QueryExecuteTemplate {
+	/**
+	 * Cursor Paging 을 적용하여 Select 를 수행한 후, 조회된 결과로 비즈니스 로직을 수행한다.
+	 * @param limit
+	 * @param selectFunction
+	 * @param resultConsumer
+	 * @param <T>
+	 */
+	public static <T> void selectAndExecuteWithCursor(int limit, Function<T, List<T>> selectFunction,
+		Consumer<List<T>> resultConsumer) {
+		List<T> resultList = null;
+		do {
+			resultList = selectFunction.apply(resultList != null ? resultList.get(resultList.size() - 1) : null);
+
+			if (!resultList.isEmpty()) {
+				resultConsumer.accept(resultList);
+			}
+		} while (resultList.size() >= limit);
+	}
+}


### PR DESCRIPTION
## 구현 사항  
- 특정 사용자의 전체 정보를 조회 하는 API를 개발합니다.  
- 해당 사용자가 개설한 모든 계좌의 정보와, 모든 거래 내역을 조회할 수 있어야 합니다.  
- 해당 API를 두 가지 방법으로 개발하고, 각각에 대해 성능 테스트를 수행해 주세요.  

## 사용자 전체 정보 조회(모든 계좌 정보, 모든 거래 내역)을 조회하는 API 1  
- 입력 받은 사용자 아이디를 바탕으로 사용자의 전체 정보를 반환합니다.  
- 특정 계좌와 연관된 모든 거래 내역을 조회하는 과정에서 병렬 처리가 가능하다고 생각했습니다.  
- 예를 들어 A계좌와 연관된 모든 거래 내역을 조회하는 과정과 B계좌와 연관된 모든 거래 내역을 조회하는 과정은 서로 연관 관계가 없기 때문에 병렬로 처리할 수 있습니다.  
- 따라서 병렬 처리를 통해 특정 사용자의 전체 정보를 조회하도록 구현했습니다.  

## 사용자 전체 정보 조회(모든 계좌 정보, 모든 거래 내역)을 조회하는 API 2  
- 입력 받은 사용자 아이디를 바탕으로 사용자의 전체 정보를 반환합니다.  
- 비교를 위해 병렬 처리를 하지 않고 특정 사용자의 전체 정보를 조회하도록 구현했습니다.  

## 성능테스트  
## 시나리오 1:  API 1 (병렬 처리 방식) 성능 테스트  
- 목표: 병렬 처리를 사용해 각 계좌의 거래 내역 조회를 동시에 수행하는 방식의 성능을 테스트합니다.  
- 방식:  
  - 100명의 동시 사용자가 API 1 요청을 보냅니다.  
  - 연관된 거래 내역이 많은 특정 계좌 번호를 요청에 포함했습니다.  
  - API 2와 비교가 가능하도록 같은 요청 데이터를 포함하여 API 1을 호출하도록 했습니다.  
- 결과:  
![image](https://github.com/user-attachments/assets/e8b8925b-c4dd-4f96-ad51-52503c17b30b)  
  
## 시나리오 2:  API 2 (병렬 처리 방식) 성능 테스트  
- 목표: 병렬 처리를 사용하지 않고 각 계좌의 거래 내역 조회를 동시에 수행하는 방식의 성능을 테스트합니다.  
- 방식:  
  - 100명의 동시 사용자가 API 2 요청을 보냅니다.  
  - 연관된 거래 내역이 많은 특정 계좌 번호를 요청에 포함했습니다.  
  - API 1과 비교가 가능하도록 같은 요청 데이터를 포함하여 API 2를 호출하도록 했습니다.  
- 결과:  
![image](https://github.com/user-attachments/assets/53c18541-cf47-42f5-bc95-68df6c55f130)  
  
## 비교 결과  
Total Requests per Second (RPS)  
- 시나리오 1: RPS가 약 200-260으로 유지되었습니다.  
- 시나리오 2: RPS가 약 16-20으로, 요청 실패율은 0%로 안정적이지만, RPS 자체는 상당히 낮은 편입니다.  

Response Times (ms)  
- 시나리오 1:  
  - 50th Percentile: 약 300-500ms로 안정적이었고, 응답 시간이 짧았습니다.  
  - 95th Percentile: 약 500-800ms로, 일부 요청에서 다소 긴 응답 시간이 있었으나 비교적 안정적입니다.  
- 시나리오 2:  
  - 50th Percentile: 약 3,000-5,000ms로 상당히 높습니다.  
  - 95th Percentile: 약 5,000-10,000ms로 응답 시간이 크게 증가하여, 상위 5%의 요청이 10초 이상 걸리는 경우도 있습니다.  